### PR TITLE
Fix issue with multiple toolbars appearing on each image, ensuring that each image only ever has a single attached toolbar.

### DIFF
--- a/DistortableImage.js
+++ b/DistortableImage.js
@@ -743,8 +743,16 @@ L.DistortableImage.Edit = L.Handler.extend({
 	},
 
 	_showToolbar: function(event) {
-		new L.Toolbar.Popup(event.latlng, L.DistortableImage.EDIT_TOOLBAR)
-			.addTo(this._overlay._map, this._overlay);
+		var overlay = this._overlay,
+			map = overlay._map;
+
+		/* Ensure that there is only ever one toolbar attached to each image. */
+		if (this.toolbar) {
+			map.removeLayer(this.toolbar);
+		}
+
+		this.toolbar = new L.Toolbar.Popup(event.latlng, L.DistortableImage.EDIT_TOOLBAR)
+			.addTo(map, overlay);
 	},
 
 	toggleIsolate: function() {

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -187,8 +187,16 @@ L.DistortableImage.Edit = L.Handler.extend({
 	},
 
 	_showToolbar: function(event) {
-		new L.Toolbar.Popup(event.latlng, L.DistortableImage.EDIT_TOOLBAR)
-			.addTo(this._overlay._map, this._overlay);
+		var overlay = this._overlay,
+			map = overlay._map;
+
+		/* Ensure that there is only ever one toolbar attached to each image. */
+		if (this.toolbar) {
+			map.removeLayer(this.toolbar);
+		}
+
+		this.toolbar = new L.Toolbar.Popup(event.latlng, L.DistortableImage.EDIT_TOOLBAR)
+			.addTo(map, overlay);
 	},
 
 	toggleIsolate: function() {


### PR DESCRIPTION
Addresses manleyjster/Leaflet.Toolbar/issues/2.  After taking a look a the Leaflet.Toolbar code, I decided that this was an issue for application code, rather than library code.

It was a small fix, really.  In `DistortableImage.Edit#_showToolbar`, I added:

``` javascript
if (this.toolbar) {
    map.removeLayer(this.toolbar);
}
```
