### PR TITLE
added event for toolbar creation, needed to override toolbar actions in ...

### DIFF
--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -239,6 +239,7 @@ L.DistortableImage.Edit = L.Handler.extend({
 		else { point = event.target._dragStartTarget._leaflet_pos; }
 		var raised_point = map.containerPointToLatLng(new L.Point(point.x,point.y-20));
 		this.toolbar = new L.DistortableImage.EditToolbar(raised_point).addTo(map, overlay);
+		overlay.fire('toolbar:created');
 	},
 
 	toggleIsolate: function() {


### PR DESCRIPTION
...application code

toolbar creation happens at the end of _showToolbar, which means that the 'select' event is not adequate for overriding or adding toolbar event handlers. This (which I've namespaced, but open to different naming conventions) allows for code like:

````js
// Override default delete to add a confirm()
img.on('toolbar:created', 
  function() {
    this.editing.toolbar.options.actions[1].prototype.add    Hooks = function() {
      var map = this._map;
      this._overlay.fire('delete');
    }
  }, img)
````

which in this example stops LDI from deleting the image from the Leaflet environment; allowing the application to do that later in a custom handler for the 'delete' event. In MapKnitter, this'd happen after a javascript `confirm('Are you sure?')` dialog.