### PR TITLE
add gecko3d to getRotateString method for Firefox

### DIFF
--- a/src/util/DomUtil.js
+++ b/src/util/DomUtil.js
@@ -25,7 +25,7 @@ L.DomUtil = L.extend(L.DomUtil, {
 	},
 
 	getRotateString: function(angle, units) {
-		var is3d = L.Browser.webkit3d,
+		var is3d = L.Browser.webkit3d || L.Browser.gecko3d,
 			open = 'rotate' + (is3d ? '3d' : '') + '(',
 			rotateString = (is3d ? '0, 0, 1, ' : '') + angle + units;
 			


### PR DESCRIPTION
I don't think getRotateString is called from within our source, but this is probably still a good idea. 