### PR TITLE
An improvement to the placement of the toolbar.

### DIFF
--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -1506,12 +1506,20 @@ L.DistortableImage.Edit = L.Handler.extend({
 		this._hideToolbar();
 		
 		var point;
-		// if (event.containerPoint) { point = event.containerPoint; }
-		// point = target._leaflet_pos;
 		point = overlay._image._leaflet_pos;
 		
-		var raised_point = map.containerPointToLatLng(new L.Point(point.x,point.y-20));
-		raised_point.lng = overlay.getCenter().lng;
+		//Find the topmost point on the image.
+		var corners = overlay.getCorners();
+		var maxLat = -Infinity;
+		for(var i = 0; i < corners.length; i++) {
+			if(corners[i].lat > maxLat) {
+				maxLat = corners[i].lat;
+			}
+		}
+
+		//Longitude is based on the centroid of the image.
+		var raised_point = overlay.getCenter();
+		raised_point.lat = maxLat;
 	
 		if (this._overlay.options.suppressToolbar !== true) {
 			this.toolbar = new L.DistortableImage.EditToolbar(raised_point).addTo(map, overlay);

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -342,12 +342,20 @@ L.DistortableImage.Edit = L.Handler.extend({
 		this._hideToolbar();
 		
 		var point;
-		// if (event.containerPoint) { point = event.containerPoint; }
-		// point = target._leaflet_pos;
 		point = overlay._image._leaflet_pos;
 		
-		var raised_point = map.containerPointToLatLng(new L.Point(point.x,point.y-20));
-		raised_point.lng = overlay.getCenter().lng;
+		//Find the topmost point on the image.
+		var corners = overlay.getCorners();
+		var maxLat = -Infinity;
+		for(var i = 0; i < corners.length; i++) {
+			if(corners[i].lat > maxLat) {
+				maxLat = corners[i].lat;
+			}
+		}
+
+		//Longitude is based on the centroid of the image.
+		var raised_point = overlay.getCenter();
+		raised_point.lat = maxLat;
 	
 		if (this._overlay.options.suppressToolbar !== true) {
 			this.toolbar = new L.DistortableImage.EditToolbar(raised_point).addTo(map, overlay);


### PR DESCRIPTION
(Bare with me, this is my first commit :D)

I noticed that the placement of the toolbar was based off a fixed increase:
``map.containerPointToLatLng(new L.Point(point.x,point.y-20));``

This wasn't preferable in certain distortions/positions/rotations so I wrote a script (see commit), that finds the corner with the highest latitude, then uses that as a 'y' position. There was no modification for the logic of 'x', that is still based off the centroid.

I tested the code profusely, it looks better.

I can provide a website to a demo of this edit on request, though it is in development currently so 404's may be expected.

Also interested in any feedback regarding my commit etiquette as this is a new thing for me.