### PR TITLE
Updated L.LatLng initializers to class factory syntax

### DIFF
--- a/test/SpecHelper.js
+++ b/test/SpecHelper.js
@@ -32,7 +32,7 @@ beforeEach(function() {
 /* 
  * Asserts that two latlngs are close. 
  * For example: 
- *     > expect(new L.LatLng(0, 0.00005)).to.be.closeToLatLng(new L.LatLng(0, 0))
+ *     > expect(L.latLng(0, 0.00005)).to.be.closeToLatLng(L.latLng(0, 0))
  *     > true
  */
 chai.use(function(chai, utils) {

--- a/test/src/DistortableCollectionSpec.js
+++ b/test/src/DistortableCollectionSpec.js
@@ -9,19 +9,19 @@ describe("L.DistortableCollection", function () {
 
     overlay = L.distortableImageOverlay('/examples/example.png', {
       corners: [
-        new L.LatLng(41.7934, -87.6052),
-        new L.LatLng(41.7934, -87.5852),
-        new L.LatLng(41.7834, -87.5852),
-        new L.LatLng(41.7834, -87.6052)
+        L.latLng(41.7934, -87.6052),
+        L.latLng(41.7934, -87.5852),
+        L.latLng(41.7834, -87.5852),
+        L.latLng(41.7834, -87.6052)
       ]
     }).addTo(map);
 
     overlay2 = L.distortableImageOverlay('/examples/example.png', {
       corners: [
-        new L.LatLng(41.7934, -87.6050),
-        new L.LatLng(41.7934, -87.5850),
-        new L.LatLng(41.7834, -87.5850),
-        new L.LatLng(41.7834, -87.6050)
+        L.latLng(41.7934, -87.6050),
+        L.latLng(41.7934, -87.5850),
+        L.latLng(41.7834, -87.5850),
+        L.latLng(41.7834, -87.6050)
       ]
     }).addTo(map);
 

--- a/test/src/DistortableImageOverlaySpec.js
+++ b/test/src/DistortableImageOverlaySpec.js
@@ -16,10 +16,10 @@ describe("L.DistortableImageOverlay", function() {
 
 		distortable = L.distortableImageOverlay('/examples/example.png', {
 			corners: [
-				new L.LatLng(41.7934, -87.6052),
-				new L.LatLng(41.7934, -87.5852),
-				new L.LatLng(41.7834, -87.5852),
-				new L.LatLng(41.7834, -87.6052)
+				L.latLng(41.7934, -87.6052),
+				L.latLng(41.7934, -87.5852),
+				L.latLng(41.7834, -87.5852),
+				L.latLng(41.7834, -87.6052)
 			]
 		});
 	});
@@ -44,7 +44,7 @@ describe("L.DistortableImageOverlay", function() {
 			L.DomEvent.on(distortable._image, 'load', function() {
 				var center = distortable.getCenter();
 
-				expect(center).to.be.closeToLatLng(new L.LatLng(41.7884, -87.5952));
+				expect(center).to.be.closeToLatLng(L.latLng(41.7884, -87.5952));
 				done();
 			});
 		});

--- a/test/src/DistortableImageOverlaySpec.js
+++ b/test/src/DistortableImageOverlaySpec.js
@@ -44,7 +44,7 @@ describe("L.DistortableImageOverlay", function() {
 			L.DomEvent.on(distortable._image, 'load', function() {
 				var center = distortable.getCenter();
 
-				expect(center).to.be.closeToLatLng(L.latLng(41.7884, -87.5952));
+				expect(center).to.be.closeToLatLng(new L.LatLng(41.7884, -87.5952));
 				done();
 			});
 		});


### PR DESCRIPTION
Fixes #248

Leaflet objects are created without using the new keyword. This is achieved by complementing each class with a lowercase factory method. For this reason:

Removed the `new` keyword from the following code blocks and updated `L.LatLng` to `L.latLng`.
