### PR TITLE
Class Factories

### DIFF
--- a/test/src/DistortableImageOverlaySpec.js
+++ b/test/src/DistortableImageOverlaySpec.js
@@ -16,10 +16,10 @@ describe("L.DistortableImageOverlay", function() {
 
 		distortable = new L.DistortableImageOverlay('/examples/example.jpg', {
 			corners: [
-				new L.LatLng(41.7934, -87.6052),
-				new L.LatLng(41.7934, -87.5852),
-				new L.LatLng(41.7834, -87.5852),
-				new L.LatLng(41.7834, -87.6052)
+				L.latLng(41.7934, -87.6052),
+				L.latLng(41.7934, -87.5852),
+				L.latLng(41.7834, -87.5852),
+				L.latLng(41.7834, -87.6052)
 			]
 		});
 	});


### PR DESCRIPTION
We use Leaflet's built-in L.LatLng to initialize the starting positions of our images corners, but we don't take advantage of their suggested class factory syntax.

Fixes #0000 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updates
* [ ] @mention the original creator of the issue in a comment below for help or for a review

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
