### PR TITLE
Keyword Change (AGAIN)

### DIFF
--- a/test/src/edit/RotateHandleSpec.js
+++ b/test/src/edit/RotateHandleSpec.js
@@ -7,10 +7,10 @@ describe("L.RotateHandle", function() {
 		map = L.map(L.DomUtil.create('div', '', document.body)).setView([41.7896,-87.5996], 15);
 		distortable = L.distortableImageOverlay('/examples/example.jpg', {
 			corners: [
-				new L.LatLng(41.7934, -87.6052),
-				new L.LatLng(41.7934, -87.5852),
-				new L.LatLng(41.7834, -87.5852),
-				new L.LatLng(41.7834, -87.6052)
+				L.latLng(41.7934, -87.6052),
+				L.latLng(41.7934, -87.5852),
+				L.latLng(41.7834, -87.5852),
+				L.latLng(41.7834, -87.6052)
 			]
 		}).addTo(map);
 


### PR DESCRIPTION
We use Leaflet's built-in L.LatLng to initialize the starting positions of our images corners, but we don't take advantage of their suggested class factory syntax.

