### PR TITLE
Fix Firefox Zoom animation

### DIFF
--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -355,9 +355,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     /* See L.DomUtil.setPosition. Mainly for the purposes of L.Draggable. */
     image._leaflet_pos = topLeft;
 
-    if (!L.Browser.gecko) {
-      image.style[L.DomUtil.TRANSFORM] = [translation, warp].join(" ");
-    }
+    image.style[L.DomUtil.TRANSFORM] = [translation, warp].join(" ");
   },
 
   getCorners: function() {

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -214,9 +214,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     /* See L.DomUtil.setPosition. Mainly for the purposes of L.Draggable. */
     image._leaflet_pos = topLeft;
 
-    if (!L.Browser.gecko) {
-      image.style[L.DomUtil.TRANSFORM] = [translation, warp].join(" ");
-    }
+    image.style[L.DomUtil.TRANSFORM] = [translation, warp].join(" ");
   },
 
   getCorners: function() {


### PR DESCRIPTION
Fixes #42  (<=== Add issue number here)

- Pulled out from #339 as requested
- Firefox zoom animation was turned off in #42 because of radical distortions in the corners. However, I am now seeing only the same distortions as the ones you find in chrome, so I think zoom animation can be turned back on now! 

- removed conditional part of:

```JS
if (!L.Browser.gecko) {
      image.style[L.DomUtil.TRANSFORM] = [translation, warp].join(" ");
    }
```
- Should we move forward with this and close #42 on merge? @jywarren  (see gif below)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updates
* [ ] @mention the original creator of the issue in a comment below for help or for a review

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
