### PR TITLE
Fix _showMarkers when toolbar is disabled

### DIFF
--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -447,18 +447,16 @@ L.DistortableImage.Edit = L.Handler.extend({
   _showMarkers: function() {
     if (this._mode === 'lock') { return; }
 
-    if (this.toolbar && this.toolbar instanceof L.DistortableImage.PopupBar) {
-      var currentHandle = this._handles[this._mode];
+    var currentHandle = this._handles[this._mode];
 
-      currentHandle.eachLayer(function (layer) {
-        var drag = layer.dragging,
+    currentHandle.eachLayer(function (layer) {
+      var drag = layer.dragging,
           opts = layer.options;
 
-        layer.setOpacity(1);
-        if (drag) { drag.enable(); }
-        if (opts.draggable) { opts.draggable = true; }
-      });
-    }
+      layer.setOpacity(1);
+      if (drag) { drag.enable(); }
+      if (opts.draggable) { opts.draggable = true; }
+    });
   },
 
   _hideMarkers: function() {


### PR DESCRIPTION
Fixes #0000 (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updates
* [ ] @mention the original creator of the issue in a comment below for help or for a review

Hello,

This PR fixes a bug happening when you don't use the toolbar. Markers randomly disappear after drag, due to the condition of toolbar which isn't fulfilled. Removing this condition solves the issue.