### PR TITLE
fix scale/rotate/rotateScale distortions + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,13 +374,15 @@ Defaults:
 
 - [`getCorners()`](#corners) and [`getCorner(idx)`](#corners)
 
+- `setCorner(idx, latLng)` and `setCorners(corners)`
+
 - `getCenter()` - Calculates the centroid of the image.
 
-- `scaleBy(num)` - scales the image by the given ratio, updating image, and where relevant, marker, and toolbar positioning.
+- `scaleBy(num)` - scales the image by the given ratio, updating image and, where applicable, markers and toolbar positioning.
    - ex. `overlay.scaleBy(0.5)`
    - a scale of 1 will leave the image unchanged
    - a scale of 0 will leave the image unchanged - dilation cannot have scale factor 0.
-   - a negative scale will invert the image, then change its size depending on the scale value
+   - a negative scale will invert the image and change its size depending on the scale value
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -374,15 +374,34 @@ Defaults:
 
 - [`getCorners()`](#corners) and [`getCorner(idx)`](#corners)
 
-- `setCorner(idx, latLng)` and `setCorners(corners)`
+- `setCorner(idx, latLng)` - update an individual image corner and, where applicable, marker and toolbar positioning. We use this internally for `distort` mode.
+
+- `setCorners(corners)` - same as`setCorner`, but takes in a "corners" object to update all 4 corners. We use this internally for image translation, rotation, and scaling. 
+   - Ex. 
+   ```JS
+   /** keys: 0-4, values: L.latLng objects for desired corner positions */
+    scaledCorners = {0: '', 1: '', 2: '', 3: ''};
+
+    for (i = 0; i < 4; i++) {
+      p = map
+        .project(this.getCorner(i))
+        .subtract(center)
+        .multiplyBy(scale)
+        .add(center);
+      scaledCorners[i] = map.unproject(p);
+    }
+
+    this.setCorners(scaledCorners);
+  ```
 
 - `getCenter()` - Calculates the centroid of the image.
 
-- `scaleBy(num)` - scales the image by the given ratio, updating image and, where applicable, markers and toolbar positioning.
+- `scaleBy(num)` - scales the image by the given ratio and calls `setCorners`.
    - ex. `overlay.scaleBy(0.5)`
-   - a scale of 1 will leave the image unchanged
-   - a scale of 0 will leave the image unchanged - dilation cannot have scale factor 0.
-   - a negative scale will invert the image and change its size depending on the scale value
+   - a scale of 0 or 1 will leave the image unchanged - but 0 causes the function to automatically return
+   - a negative scale will invert the image and, depending on the scale value, change its size
+
+- `rotateBy(rad)` - rotates the image by the given radian angle and calls `setCorners`.
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Defaults:
 
 - `setCorner(idx, latLng)` - update an individual image corner and, where applicable, marker and toolbar positioning. We use this internally for `distort` mode.
 
-- `setCorners(corners)` - same as`setCorner`, but takes in a "corners" object to update all 4 corners. We use this internally for image translation, rotation, and scaling. 
+- `setCorners(corners)` - same as`setCorner`, but takes in a "corners" object to update all 4 corners with only one UI update at the end. We use this internally for image translation, rotation, and scaling. 
    - Ex. 
    ```JS
    /** keys: 0-4, values: L.latLng objects for desired corner positions */

--- a/README.md
+++ b/README.md
@@ -376,6 +376,12 @@ Defaults:
 
 - `getCenter()` - Calculates the centroid of the image.
 
+- `scaleBy(num)` - scales the image by the given ratio, updating image, and where relevant, marker, and toolbar positioning.
+   - ex. `overlay.scaleBy(0.5)`
+   - a scale of 1 will leave the image unchanged
+   - a scale of 0 will leave the image unchanged - dilation cannot have scale factor 0.
+   - a negative scale will invert the image, then change its size depending on the scale value
+
 <hr>
 
 `L.DistortableCollection`

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -760,7 +760,10 @@ L.DistortableCollection = L.FeatureGroup.extend({
     var box = e.boxZoomBounds;
 
     this.eachLayer(function(layer) {
-      var imgBounds = new L.latLngBounds(layer.getCorner(2), layer.getCorner(1));
+      var edit = layer.editing;
+      if (edit._selected) { edit._deselect(); }
+
+      var imgBounds = L.latLngBounds(layer.getCorner(2), layer.getCorner(1));
       imgBounds = this._map._latLngBoundsToNewLayerBounds(imgBounds, this._map.getZoom(), this._map.getCenter());
       if (box.intersects(imgBounds)) {
         if (!this.toolbar) { this._addToolbar(); }

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -349,7 +349,6 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     }
   },
 
-  // fires a reset after all corner positions are updated instead of after each one (above). Use if you're updating all 4 corners
   setCorners: function(latlngObj) {
     var edit = this.editing,
         i = 0;

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -757,14 +757,15 @@ L.DistortableCollection = L.FeatureGroup.extend({
   },
 
   _addSelections: function(e) {
-    var box = e.boxZoomBounds;
+    var box = e.boxZoomBounds,
+        map = this._map;
 
     this.eachLayer(function(layer) {
       var edit = layer.editing;
       if (edit._selected) { edit._deselect(); }
 
       var imgBounds = L.latLngBounds(layer.getCorner(2), layer.getCorner(1));
-      imgBounds = this._map._latLngBoundsToNewLayerBounds(imgBounds, this._map.getZoom(), this._map.getCenter());
+      imgBounds = map._latLngBoundsToNewLayerBounds(imgBounds, map.getZoom(), map.getCenter());
       if (box.intersects(imgBounds)) {
         if (!this.toolbar) { this._addToolbar(); }
         L.DomUtil.addClass(layer.getElement(), 'selected');

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -1336,7 +1336,9 @@ L.RotateHandle = L.EditHandle.extend({
 			newLatLng = this.getLatLng(),
 			angle = this.calculateAngleDelta(formerLatLng, newLatLng);
 
-	 	if (angle !== 0) { overlay.rotateBy(angle); }
+		/** running rotation logic even for an angle delta of 0 
+		 * prevents a small, occasional marker flicker */
+	 	overlay.rotateBy(angle);
 	},
 
 	updateHandle: function() {
@@ -1376,7 +1378,8 @@ L.ScaleHandle = L.EditHandle.extend({
 
 		if (distance > edgeMinWidth|| scale > 1) {
 			overlay.scaleBy(scale);
-		/** scaling by 1 instead of just not scaling at all prevents a small marker flicker */
+		/** running scale logic even for a scale ratio of 1
+		 * prevents a small, occasional marker flicker */
 		} else {
 			overlay.scaleBy(1);
 		}

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -428,6 +428,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
   _revert: function() {
     var angle = this.rotation,
         map = this._map,
+        edit =  this.editing,
         center = map.project(this.getCenter()),
         offset = this._initialDimensions.offset,
         corners = { 
@@ -437,15 +438,13 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
           3: map.unproject(center.add(offset))
         };
 
-    map.removeLayer(this.editing._handles[this.editing._mode]);
+    map.removeLayer(edit._handles[edit._mode]);
 
     this.setCorners(corners);
 
     if (angle !== 0) { this.rotateBy(L.TrigUtil.degreesToRadians(360 - angle)); }
 
-    map.addLayer(this.editing._handles[this.editing._mode]);
-
-    // this._updateToolbarPos();
+    map.addLayer(edit._handles[edit._mode]);
 
     this.rotation = angle;
 },

--- a/src/DistortableCollection.js
+++ b/src/DistortableCollection.js
@@ -164,14 +164,15 @@ L.DistortableCollection = L.FeatureGroup.extend({
   },
 
   _addSelections: function(e) {
-    var box = e.boxZoomBounds;
+    var box = e.boxZoomBounds,
+        map = this._map;
 
     this.eachLayer(function(layer) {
       var edit = layer.editing;
       if (edit._selected) { edit._deselect(); }
 
       var imgBounds = L.latLngBounds(layer.getCorner(2), layer.getCorner(1));
-      imgBounds = this._map._latLngBoundsToNewLayerBounds(imgBounds, this._map.getZoom(), this._map.getCenter());
+      imgBounds = map._latLngBoundsToNewLayerBounds(imgBounds, map.getZoom(), map.getCenter());
       if (box.intersects(imgBounds)) {
         if (!this.toolbar) { this._addToolbar(); }
         L.DomUtil.addClass(layer.getElement(), 'selected');

--- a/src/DistortableCollection.js
+++ b/src/DistortableCollection.js
@@ -167,7 +167,10 @@ L.DistortableCollection = L.FeatureGroup.extend({
     var box = e.boxZoomBounds;
 
     this.eachLayer(function(layer) {
-      var imgBounds = new L.latLngBounds(layer.getCorner(2), layer.getCorner(1));
+      var edit = layer.editing;
+      if (edit._selected) { edit._deselect(); }
+
+      var imgBounds = L.latLngBounds(layer.getCorner(2), layer.getCorner(1));
       imgBounds = this._map._latLngBoundsToNewLayerBounds(imgBounds, this._map.getZoom(), this._map.getCenter());
       if (box.intersects(imgBounds)) {
         if (!this.toolbar) { this._addToolbar(); }

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -135,7 +135,6 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     }
   },
 
-  // fires a reset after all corner positions are updated instead of after each one (above). Use if you're updating all 4 corners
   setCorners: function(latlngObj) {
     var edit = this.editing,
         i = 0;

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -214,6 +214,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
   _revert: function() {
     var angle = this.rotation,
         map = this._map,
+        edit =  this.editing,
         center = map.project(this.getCenter()),
         offset = this._initialDimensions.offset,
         corners = { 
@@ -223,15 +224,13 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
           3: map.unproject(center.add(offset))
         };
 
-    map.removeLayer(this.editing._handles[this.editing._mode]);
+    map.removeLayer(edit._handles[edit._mode]);
 
     this.setCorners(corners);
 
     if (angle !== 0) { this.rotateBy(L.TrigUtil.degreesToRadians(360 - angle)); }
 
-    map.addLayer(this.editing._handles[this.editing._mode]);
-
-    // this._updateToolbarPos();
+    map.addLayer(edit._handles[edit._mode]);
 
     this.rotation = angle;
 },

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -189,7 +189,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     this.setCorners(scaledCorners);
   },
 
-  _rotateBy: function(angle) {
+  rotateBy: function(angle) {
     var map = this._map,
         center = map.project(this.getCenter()),
         corners = {0: '', 1: '', 2: '', 3: ''},
@@ -211,6 +211,30 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     this.rotation -= L.TrigUtil.radiansToDegrees(angle);
   },
 
+  _revert: function() {
+    var angle = this.rotation,
+        map = this._map,
+        center = map.project(this.getCenter()),
+        offset = this._initialDimensions.offset,
+        corners = { 
+          0: map.unproject(center.subtract(offset)),
+          1: map.unproject(center.add(L.point(offset.x, -offset.y))),
+          2: map.unproject(center.add(L.point(-offset.x, offset.y))),
+          3: map.unproject(center.add(offset))
+        };
+
+    map.removeLayer(this.editing._handles[this.editing._mode]);
+
+    this.setCorners(corners);
+
+    if (angle !== 0) { this.rotateBy(L.TrigUtil.degreesToRadians(360 - angle)); }
+
+    map.addLayer(this.editing._handles[this.editing._mode]);
+
+    // this._updateToolbarPos();
+
+    this.rotation = angle;
+},
 
   /* Copied from Leaflet v0.7 https://github.com/Leaflet/Leaflet/blob/66282f14bcb180ec87d9818d9f3c9f75afd01b30/src/dom/DomUtil.js#L189-L199 */
   /* since L.DomUtil.getTranslateString() is deprecated in Leaflet v1.0 */

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -163,6 +163,30 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     this._reset();
   },
 
+  scaleBy: function(scale) {
+    var map = this._map,
+        center = map.project(this.getCenter()),
+        i, p,
+        scaledCorners = {0: '', 1: '', 2: '', 3: ''},
+        edit = this.editing;
+
+    for (i = 0; i < 4; i++) {
+      p = map
+        .project(this.getCorner(i))
+        .subtract(center)
+        .multiplyBy(scale)
+        .add(center);
+      scaledCorners[i] = map.unproject(p);
+    }
+
+    this.setCorners(scaledCorners);
+    this.fire('update');
+
+    if (edit.toolbar &&  edit.toolbar instanceof L.DistortableImage.PopupBar) {
+      edit._updateToolbarPos();
+    }
+  },
+
   /* Copied from Leaflet v0.7 https://github.com/Leaflet/Leaflet/blob/66282f14bcb180ec87d9818d9f3c9f75afd01b30/src/dom/DomUtil.js#L189-L199 */
   /* since L.DomUtil.getTranslateString() is deprecated in Leaflet v1.0 */
   _getTranslateString: function(point) {

--- a/src/edit/DistortHandle.js
+++ b/src/edit/DistortHandle.js
@@ -13,9 +13,6 @@ L.DistortHandle = L.EditHandle.extend({
     var overlay = this._handled;
 
     overlay.setCorner(this._corner, this.getLatLng());
-
-    overlay.fire("update");
-    overlay.editing._updateToolbarPos();
   },
 
   updateHandle: function() {

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -223,26 +223,6 @@ L.DistortableImage.Edit = L.Handler.extend({
     this._overlay.rotation = angle;
   },
 
-  _scaleBy: function(scale) {
-    var overlay = this._overlay,
-      map = overlay._map,
-      center = map.project(overlay.getCenter()),
-      i,
-      p;
-
-    for (i = 0; i < 4; i++) {
-      p = map
-        .project(overlay.getCorner(i))
-        .subtract(center)
-        .multiplyBy(scale)
-        .add(center);
-      overlay.setCorner(i, map.unproject(p));
-      console.log('corner', map.project(overlay.getCorner(i)));
-    }
-
-    overlay._reset();
-  },
-
   _enableDragging: function() {
     var overlay = this._overlay,
       map = overlay._map;

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -172,30 +172,6 @@ L.DistortableImage.Edit = L.Handler.extend({
     }, this);
   },
 
-  _rotateBy: function(angle) {
-    var overlay = this._overlay,
-      map = overlay._map,
-      center = map.latLngToLayerPoint(overlay.getCenter()),
-      i,
-      p,
-      q;
-
-    for (i = 0; i < 4; i++) {
-      p = map.latLngToLayerPoint(overlay.getCorner(i)).subtract(center);
-      q = L.point(
-        Math.cos(angle) * p.x - Math.sin(angle) * p.y,
-        Math.sin(angle) * p.x + Math.cos(angle) * p.y
-      );
-      overlay.setCorner(i, map.layerPointToLatLng(q.add(center)));
-    }
-
-    // window.angle = L.TrigUtil.radiansToDegrees(angle);
-
-    this._overlay.rotation -= L.TrigUtil.radiansToDegrees(angle);
-
-    overlay._reset();
-  },
-
   _revert: function() {
     var overlay = this._overlay;
     var angle = overlay.rotation;

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -172,33 +172,6 @@ L.DistortableImage.Edit = L.Handler.extend({
     }, this);
   },
 
-  _revert: function() {
-    var overlay = this._overlay;
-    var angle = overlay.rotation;
-    var map = overlay._map;
-    var center = map.latLngToLayerPoint(overlay.getCenter());
-    var offset = overlay._initialDimensions.offset;
-
-    var corners = { 
-      0: map.layerPointToLatLng(center.subtract(offset)),
-      1: map.layerPointToLatLng(center.add(L.point(offset.x, -offset.y))),
-      2: map.layerPointToLatLng(center.add(L.point(-offset.x, offset.y))),
-      3: map.layerPointToLatLng(center.add(offset))
-    };
-
-    map.removeLayer(this._handles[this._mode]);
-
-    overlay.setCorners(corners);
-
-    if (angle !== 0) { this._rotateBy(L.TrigUtil.degreesToRadians(360 - angle)); }
-
-    map.addLayer(this._handles[this._mode]);
-
-    this._updateToolbarPos();
-
-    this._overlay.rotation = angle;
-  },
-
   _enableDragging: function() {
     var overlay = this._overlay,
       map = overlay._map;

--- a/src/edit/RotateHandle.js
+++ b/src/edit/RotateHandle.js
@@ -14,7 +14,7 @@ L.RotateHandle = L.EditHandle.extend({
 			newLatLng = this.getLatLng(),
 			angle = this.calculateAngleDelta(formerLatLng, newLatLng);
 
-	 	if (angle !== 0) { overlay._rotateBy(angle); }
+	 	if (angle !== 0) { overlay.rotateBy(angle); }
 	},
 
 	updateHandle: function() {

--- a/src/edit/RotateHandle.js
+++ b/src/edit/RotateHandle.js
@@ -14,10 +14,7 @@ L.RotateHandle = L.EditHandle.extend({
 			newLatLng = this.getLatLng(),
 			angle = this.calculateAngleDelta(formerLatLng, newLatLng);
 
-	 	if (angle !== 0) { overlay.editing._rotateBy(angle); }
-
-		overlay.fire('update');
-		overlay.editing._updateToolbarPos();
+	 	if (angle !== 0) { overlay._rotateBy(angle); }
 	},
 
 	updateHandle: function() {

--- a/src/edit/RotateHandle.js
+++ b/src/edit/RotateHandle.js
@@ -14,7 +14,9 @@ L.RotateHandle = L.EditHandle.extend({
 			newLatLng = this.getLatLng(),
 			angle = this.calculateAngleDelta(formerLatLng, newLatLng);
 
-	 	if (angle !== 0) { overlay.rotateBy(angle); }
+		/** running rotation logic even for an angle delta of 0 
+		 * prevents a small, occasional marker flicker */
+	 	overlay.rotateBy(angle);
 	},
 
 	updateHandle: function() {

--- a/src/edit/RotateScaleHandle.js
+++ b/src/edit/RotateScaleHandle.js
@@ -10,33 +10,27 @@ L.RotateScaleHandle = L.EditHandle.extend({
 
 	_onHandleDrag: function() {
 		var overlay = this._handled,
-			edit = overlay.editing,
+			map = overlay._map,
+			edgeMinWidth = overlay.edgeMinWidth,
 			formerLatLng = overlay.getCorner(this._corner),
 			newLatLng = this.getLatLng(),
 
 			angle = this.calculateAngleDelta(formerLatLng, newLatLng),
 			scale = this._calculateScalingFactor(formerLatLng, newLatLng);
 		
-		if (angle !== 0) { edit._rotateBy(angle); }
+		if (angle !== 0) { overlay._rotateBy(angle); }
 
-		/* 
-		  checks whether the "edgeMinWidth" property is set and tracks the minimum edge length;
-		  this enables preventing scaling to zero, but we might also add an overall scale limit
-		*/		
-		if (overlay.hasOwnProperty('edgeMinWidth')){
-			var edgeMinWidth = overlay.edgeMinWidth;
-                        var corner1 = overlay._map.latLngToContainerPoint(overlay.getCorner(0)),
-                            corner2 = overlay._map.latLngToContainerPoint(overlay.getCorner(1));
-                        var w = Math.abs(corner1.x - corner2.x);
-                        var h = Math.abs(corner1.y - corner2.y);
-                        var distance = Math.sqrt(w * w + h * h);
-			if ((distance > edgeMinWidth) || scale > 1) {
-				edit._scaleBy(scale);
-			}
-		} 
-
-		overlay.fire('update');
-		edit._updateToolbarPos();
+		if (!edgeMinWidth) { edgeMinWidth = 50; } /* just in case */
+		var corner1 = map.latLngToContainerPoint(overlay.getCorner(0)),
+			corner2 = map.latLngToContainerPoint(overlay.getCorner(1)),
+			w = Math.abs(corner1.x - corner2.x),
+			h = Math.abs(corner1.y - corner2.y),
+			distance = Math.sqrt(w * w + h * h);
+		if (distance > edgeMinWidth || scale > 1) {
+			overlay.scaleBy(scale);
+		} else {
+			overlay.scaleBy(1);
+		}
 	},
 
 	updateHandle: function() {

--- a/src/edit/RotateScaleHandle.js
+++ b/src/edit/RotateScaleHandle.js
@@ -18,7 +18,7 @@ L.RotateScaleHandle = L.EditHandle.extend({
 			angle = this.calculateAngleDelta(formerLatLng, newLatLng),
 			scale = this._calculateScalingFactor(formerLatLng, newLatLng);
 		
-		if (angle !== 0) { overlay._rotateBy(angle); }
+		if (angle !== 0) { overlay.rotateBy(angle); }
 
 		if (!edgeMinWidth) { edgeMinWidth = 50; } /* just in case */
 		var corner1 = map.latLngToContainerPoint(overlay.getCorner(0)),

--- a/src/edit/ScaleHandle.js
+++ b/src/edit/ScaleHandle.js
@@ -12,13 +12,10 @@ L.ScaleHandle = L.EditHandle.extend({
 		var overlay = this._handled,
 			formerLatLng = overlay.getCorner(this._corner),
 			newLatLng = this.getLatLng(),
-
 			scale = this._calculateScalingFactor(formerLatLng, newLatLng);
 
-		overlay.editing._scaleBy(scale);
-
-		overlay.fire('update');
-		overlay.editing._updateToolbarPos();
+		if (scale  === 0) { return; }
+		if (scale !== 1) { overlay.scaleBy(scale); }
 	},
 
 	updateHandle: function() {

--- a/src/edit/ScaleHandle.js
+++ b/src/edit/ScaleHandle.js
@@ -8,14 +8,31 @@ L.ScaleHandle = L.EditHandle.extend({
 		})
 	},
 
-	_onHandleDrag: function() {
+	_onHandleDrag: function(e) {
 		var overlay = this._handled,
+			map = overlay._map,
+			edgeMinWidth = overlay.edgeMinWidth,
 			formerLatLng = overlay.getCorner(this._corner),
 			newLatLng = this.getLatLng(),
 			scale = this._calculateScalingFactor(formerLatLng, newLatLng);
 
-		if (scale  === 0) { return; }
-		if (scale !== 1) { overlay.scaleBy(scale); }
+		/* 
+		 * checks whether the "edgeMinWidth" property is set and tracks the minimum edge length;
+		 * this enables preventing scaling to zero, but we might also add an overall scale limit
+		*/		
+		if (!edgeMinWidth) { edgeMinWidth = 50; } /* just in case */
+		var corner1 = map.latLngToLayerPoint(overlay.getCorner(0)),
+			corner2 = map.latLngToLayerPoint(overlay.getCorner(1)),
+			w = Math.abs(corner1.x - corner2.x),
+			h = Math.abs(corner1.y - corner2.y),
+			distance = Math.sqrt(w * w + h * h);
+
+		if (distance > edgeMinWidth|| scale > 1) {
+			overlay.scaleBy(scale);
+		/** scaling by 1 instead of just not scaling at all prevents a small marker flicker */
+		} else {
+			overlay.scaleBy(1);
+		}
 	},
 
 	updateHandle: function() {

--- a/src/edit/ScaleHandle.js
+++ b/src/edit/ScaleHandle.js
@@ -29,7 +29,8 @@ L.ScaleHandle = L.EditHandle.extend({
 
 		if (distance > edgeMinWidth|| scale > 1) {
 			overlay.scaleBy(scale);
-		/** scaling by 1 instead of just not scaling at all prevents a small marker flicker */
+		/** running scale logic even for a scale ratio of 1
+		 * prevents a small, occasional marker flicker */
 		} else {
 			overlay.scaleBy(1);
 		}

--- a/src/edit/tools/DistortableImage.PopupBar.js
+++ b/src/edit/tools/DistortableImage.PopupBar.js
@@ -239,9 +239,7 @@ var Revert = L.EditAction.extend({
   },
 
   addHooks: function() {
-    var editing = this._overlay.editing;
-
-    editing._revert();
+    this._overlay._revert();
   }
 });
 

--- a/test/SpecHelper.js
+++ b/test/SpecHelper.js
@@ -5,7 +5,7 @@ beforeEach(function() {
 
 	/* Chain global testing utilites below to chai*/
 
-        /*
+    /*
 	 * simulate mouse events manually in the DOM on a passed element. 
 	 *   - (Most) useful parameters: 
 	 *      1) type: string - this is for 'mousedown'. Other options include 'click', 'dblick', 'mouseup', 'mouseover', 'mouseout', 'mousemove
@@ -69,21 +69,5 @@ chai.use(function(chai, utils) {
 
 		lat.to.be.closeTo(actual.lat, delta, message);
 		lng.to.be.closeTo(actual.lng, delta, message);
-	});
-
-	Assertion.addMethod('equalToPoint', function(actual) {
-		var obj = utils.flag(this, 'object');
-
-		expect(obj).to.have.property('x');
-		expect(obj).to.have.property('y');
-
-		var x = new Assertion(obj.x),
-			y = new Assertion(obj.y);
-
-		utils.transferFlags(this, x, false);
-		utils.transferFlags(this, y, false);
-
-		x.to.equal(actual.x);
-		y.to.equal(actual.y);
 	});
 });

--- a/test/SpecHelper.js
+++ b/test/SpecHelper.js
@@ -70,4 +70,20 @@ chai.use(function(chai, utils) {
 		lat.to.be.closeTo(actual.lat, delta, message);
 		lng.to.be.closeTo(actual.lng, delta, message);
 	});
+
+	Assertion.addMethod('equalToPoint', function(actual) {
+		var obj = utils.flag(this, 'object');
+
+		expect(obj).to.have.property('x');
+		expect(obj).to.have.property('y');
+
+		var x = new Assertion(obj.x),
+			y = new Assertion(obj.y);
+
+		utils.transferFlags(this, x, false);
+		utils.transferFlags(this, y, false);
+
+		x.to.equal(actual.x);
+		y.to.equal(actual.y);
+	});
 });

--- a/test/src/DistortableCollectionSpec.js
+++ b/test/src/DistortableCollectionSpec.js
@@ -1,4 +1,4 @@
-describe("L.DistortableCollection", function () {
+describe('L.DistortableCollection', function () {
     var map,
         overlay,
         overlay2,
@@ -50,18 +50,18 @@ describe("L.DistortableCollection", function () {
         imgGroup.removeLayer(overlay3);
     });
 
-    it.skip("Should keep selected images in sync with eachother during translation", function () {
+    it.skip('Should keep selected images in sync with eachother during translation', function () {
 
     });
 
-    it("Adds the layers to the map when they are added to the group", function () {
+    it('Adds the layers to the map when they are added to the group', function () {
         expect(map.hasLayer(overlay)).to.be.true;
         expect(map.hasLayer(overlay2)).to.be.true;
         expect(map.hasLayer(overlay3)).to.be.true;
     });
 
-    describe("#isSelected", function () {
-        it("Should only return true if the image was selected using command + mousedown", function() {
+    describe('#isSelected', function () {
+        it('Should only return true if the image was selected using command + mousedown', function() {
             var img = overlay.getElement(),
                 img2 = overlay2.getElement();
             
@@ -73,8 +73,8 @@ describe("L.DistortableCollection", function () {
         });
     });
 
-    describe("#anySelected", function () {
-        it("Should return false if no selections were made with command + mousedown", function() {
+    describe('#anySelected', function () {
+        it('Should return false if no selections were made with command + mousedown', function() {
             var img = overlay.getElement(),
                 img2 = overlay2.getElement();
             
@@ -86,18 +86,18 @@ describe("L.DistortableCollection", function () {
         });
     });
 
-    describe("#_deselectAll", function() {
+    describe('#_deselectAll', function() {
         it("Should remove the 'selected' class from all images", function() {
             var img = overlay.getElement(),
                 img2 = overlay2.getElement();
 
-            L.DomUtil.addClass(img, "selected");
-            L.DomUtil.addClass(img2, "selected");
+            L.DomUtil.addClass(img, 'selected');
+            L.DomUtil.addClass(img2, 'selected');
 
-            map.fire("click");
+            map.fire('click');
 
-            expect(L.DomUtil.getClass(img)).to.not.include("selected");
-            expect(L.DomUtil.getClass(img2)).to.not.include("selected");
+            expect(L.DomUtil.getClass(img)).to.not.include('selected');
+            expect(L.DomUtil.getClass(img2)).to.not.include('selected');
         });
 
         it("Should hide all images' handles unless they're lock handles", function() {
@@ -108,21 +108,21 @@ describe("L.DistortableCollection", function () {
             edit2._toggleLock();
 
             // then trigger _deselectAll
-            map.fire("click");
+            map.fire('click');
 
             var distortHandleState = [];
-            edit._handles["distort"].eachLayer(function(handle) {
+            edit._handles['distort'].eachLayer(function(handle) {
               distortHandleState.push(handle._icon.style.opacity);
             });
 
             var lockHandleState = [];
-            edit2._handles["lock"].eachLayer(function(handle) {
+            edit2._handles['lock'].eachLayer(function(handle) {
               lockHandleState.push(handle._icon.style.opacity);
             });
 
-            expect(distortHandleState).to.deep.equal(["0", "0", "0", "0"]);
+            expect(distortHandleState).to.deep.equal(['0', '0', '0', '0']);
             // opacity for lockHandles is unset because we never altered it to hide it as part of deselection
-            expect(lockHandleState).to.deep.equal(["", "", "", ""]);
+            expect(lockHandleState).to.deep.equal(['', '', '', '']);
         });
   
         it("Should remove all images' individual toolbar instances regardless of lock handles", function() {
@@ -147,25 +147,25 @@ describe("L.DistortableCollection", function () {
         });
     });
 
-    describe("#_toggleMultiSelect", function () {
-        it("Should allow multiple image selection on command + click", function() {
+    describe('#_toggleMultiSelect', function () {
+        it('Should allow multiple image selection on command + click', function() {
             var img = overlay.getElement(),
                 img2 = overlay2.getElement();
 
             chai.simulateCommandMousedown(img);
             chai.simulateCommandMousedown(img2);
 
-            expect(L.DomUtil.getClass(img)).to.include("selected");
-            expect(L.DomUtil.getClass(img2)).to.include("selected");
+            expect(L.DomUtil.getClass(img)).to.include('selected');
+            expect(L.DomUtil.getClass(img2)).to.include('selected');
         });
 
-        it("It should allow a locked image to be part of multiple image selection", function() {
+        it('It should allow a locked image to be part of multiple image selection', function() {
             var img = overlay.getElement();
 
             overlay.editing._toggleLock();
             chai.simulateCommandMousedown(img);
 
-            expect(L.DomUtil.getClass(img)).to.include("selected");
+            expect(L.DomUtil.getClass(img)).to.include('selected');
         });
     });
 

--- a/test/src/DistortableImageOverlaySpec.js
+++ b/test/src/DistortableImageOverlaySpec.js
@@ -1,10 +1,10 @@
-describe("L.DistortableImageOverlay", function() {
+describe('L.DistortableImageOverlay', function() {
 	var map,
-		distortable;
+		overlay;
 
-	beforeEach(function() {
+	beforeEach(function(done) {
 		var mapContainer = L.DomUtil.create('div', '', document.body),
-			fullSize = [document.querySelector("html"), document.body, mapContainer];
+			fullSize = [document.querySelector('html'), document.body, mapContainer];
 
 		map = L.map(mapContainer).setView([41.7896,-87.5996], 15);
 
@@ -14,39 +14,86 @@ describe("L.DistortableImageOverlay", function() {
 			fullSize[i].style.height = '100%';
 		}
 
-		distortable = L.distortableImageOverlay('/examples/example.png', {
+		overlay = L.distortableImageOverlay('/examples/example.png', {
 			corners: [
 				L.latLng(41.7934, -87.6052),
 				L.latLng(41.7934, -87.5852),
 			    L.latLng(41.7834, -87.6052),
 				L.latLng(41.7834, -87.5852)
 			]
+		}).addTo(map);
+
+		/* Forces the image to load before any tests are run. */
+		L.DomEvent.on(overlay._image, 'load', function() { done (); });
+
+		afterEach(function () {
+			L.DomUtil.remove(overlay);
 		});
 	});
 
-	describe("#_calculateProjectiveTransform", function() {
-		it.skip("Should", function() {
+	describe('#_calculateProjectiveTransform', function() {
+		it.skip('Should', function() {
 			var matrix;
 
 			/* _map is set when #onAdd is called. */
-			distortable._map = map;
-			distortable._initImage();
+			overlay._map = map;
+			overlay._initImage();
 
-			matrix = distortable._calculateProjectiveTransform();
+			matrix = overlay._calculateProjectiveTransform();
 			expect(matrix).to.equal([]);
 		});
 	});
 
-	describe("#getCenter", function() {
-		it("Should return the center when the outline of the image is a rectangle.", function(done) {
-			distortable.addTo(map);
-			
-			L.DomEvent.on(distortable._image, 'load', function() {
-				var center = distortable.getCenter();
+	describe('#getCenter', function() {
+		it('Should return the center when the outline of the image is a rectangle', function() {
+			var center = overlay.getCenter();
 
-				expect(center).to.be.closeToLatLng(L.latLng(41.7884, -87.5952));
-				done();
-			});
+			expect(center).to.be.closeToLatLng(L.latLng(41.7884, -87.5952));
+		});
+	});
+
+	describe('#scaleBy', function() {
+		it('Should not change image dimensions when passed a value of 1 or 0', function() {
+			var img = overlay.getElement(),
+				dims = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
+
+			overlay.scaleBy(1);
+
+			var scaledDims = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
+			expect(dims).to.be.eql(scaledDims);
+
+			overlay.scaleBy(0);
+
+			var scaledDims2 = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
+			expect(dims).to.be.eql(scaledDims2);
+		});
+
+		it('Should invert image dimensions when passed a negative value', function() {
+			var c2 = overlay.getCorner(2), 
+				c3 = overlay.getCorner(3);
+
+            overlay.scaleBy(-1);
+ 
+			var scaledC = overlay.getCorner(0), 
+				scaledC1 = overlay.getCorner(1);
+
+            expect(Math.round(scaledC.lat)).to.equal(Math.round(c3.lat));
+            expect(Math.round(scaledC.lng)).to.equal(Math.round(c3.lng));
+            expect(Math.round(scaledC1.lat)).to.equal(Math.round(c2.lat));
+            expect(Math.round(scaledC1.lng)).to.equal(Math.round(c2.lng));
+		});
+		
+		it('Maintain image proportions when scaling', function() {
+			var w = overlay.getElement().getBoundingClientRect().width,
+				h = overlay.getElement().getBoundingClientRect().height;
+
+			overlay.scaleBy(0.5);
+
+			var w2 = overlay.getElement().getBoundingClientRect().width,
+				h2 = overlay.getElement().getBoundingClientRect().height;
+
+			expect(Math.round(w / 2)).to.be.equal(Math.round(w2));
+			expect(Math.round(h / 2)).to.be.equal(Math.round(h2));
 		});
 	});
 });

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -101,7 +101,7 @@ describe("L.DistortableImage.Edit", function() {
             expect(Math.round(scaledC1.lng)).to.equal(Math.round(c2.lng));
 		});
 		
-		it('Keeps image proportions when scaling', function() {
+		it('Maintain image proportions when scaling', function() {
 			var w = overlay.getElement().getBoundingClientRect().width,
 				h = overlay.getElement().getBoundingClientRect().height;
 

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -36,8 +36,7 @@ describe("L.DistortableImage.Edit", function() {
 		chai.simulateClick(img);
 
 		overlay.setCorner(0, L.latLng(41.7934, -87.6252));
-		overlay.fire('update');
-		
+
 		/* Warp handles are currently on the map; they should have been updated. */
 		edit._distortHandles.eachLayer(function(handle) {
 			expect(handle.getLatLng()).to.be.closeToLatLng(corners[handle._corner]);
@@ -48,70 +47,6 @@ describe("L.DistortableImage.Edit", function() {
 		/* After we toggle modes, the rotateScaleHandles are on the map and should be synced. */
 		edit._rotateScaleHandles.eachLayer(function(handle) {
 			expect(handle.getLatLng()).to.be.closeToLatLng(corners[handle._corner]);
-		});
-	});
-
-	it.skip("Should keep image in sync with the map while dragging.", function() {
-		var edit = overlay.editing,
-			dragging;
-
-		edit.enable();
-
-		dragging = edit.dragging;
-
-		/* _reset is not called by #onAdd, for some reason... */
-		overlay._reset();
-
-		/* Simulate a sequence of drag events. */
-		dragging._onDown({ touches: [{ clientX: 0, clientY: 0 }], target: overlay._image });
-		dragging._onMove({ touches: [{ clientX: 20, clientY: 30 }], target: overlay._image });
-		dragging._onUp();
-
-		map.setView([41.7896,-87.6996]);
-	});
-
-	describe('#scaleBy', function() {
-		it('Should not change image dimensions when passed a value of 1 or 0', function() {
-			var img = overlay.getElement(),
-				dims = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
-
-			overlay.scaleBy(1);
-
-			var scaledDims = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
-			expect(dims).to.be.eql(scaledDims);
-
-			overlay.scaleBy(0);
-
-			var scaledDims2 = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
-			expect(dims).to.be.eql(scaledDims2);
-		});
-
-		it('Should invert image dimensions when passed a negative value', function() {
-			var c2 = overlay.getCorner(2), 
-				c3 = overlay.getCorner(3);
-
-            overlay.scaleBy(-1);
- 
-			var scaledC = overlay.getCorner(0), 
-				scaledC1 = overlay.getCorner(1);
-
-            expect(Math.round(scaledC.lat)).to.equal(Math.round(c3.lat));
-            expect(Math.round(scaledC.lng)).to.equal(Math.round(c3.lng));
-            expect(Math.round(scaledC1.lat)).to.equal(Math.round(c2.lat));
-            expect(Math.round(scaledC1.lng)).to.equal(Math.round(c2.lng));
-		});
-		
-		it('Maintain image proportions when scaling', function() {
-			var w = overlay.getElement().getBoundingClientRect().width,
-				h = overlay.getElement().getBoundingClientRect().height;
-
-			overlay.scaleBy(0.5);
-
-			var w2 = overlay.getElement().getBoundingClientRect().width,
-				h2 = overlay.getElement().getBoundingClientRect().height;
-
-			expect(Math.round(w / 2)).to.be.equal(Math.round(w2));
-			expect(Math.round(h / 2)).to.be.equal(Math.round(h2));
 		});
 	});
 

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -70,6 +70,51 @@ describe("L.DistortableImage.Edit", function() {
 		map.setView([41.7896,-87.6996]);
 	});
 
+	describe('#scaleBy', function() {
+		it('Should not change image dimensions when passed a value of 1 or 0', function() {
+			var img = overlay.getElement(),
+				dims = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
+
+			overlay.scaleBy(1);
+
+			var scaledDims = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
+			expect(dims).to.be.eql(scaledDims);
+
+			overlay.scaleBy(0);
+
+			var scaledDims2 = [img.getBoundingClientRect().width, img.getBoundingClientRect().height];
+			expect(dims).to.be.eql(scaledDims2);
+		});
+
+		it('Should invert image dimensions when passed a negative value', function() {
+			var c2 = overlay.getCorner(2), 
+				c3 = overlay.getCorner(3);
+
+            overlay.scaleBy(-1);
+ 
+			var scaledC = overlay.getCorner(0), 
+				scaledC1 = overlay.getCorner(1);
+
+            expect(Math.round(scaledC.lat)).to.equal(Math.round(c3.lat));
+            expect(Math.round(scaledC.lng)).to.equal(Math.round(c3.lng));
+            expect(Math.round(scaledC1.lat)).to.equal(Math.round(c2.lat));
+            expect(Math.round(scaledC1.lng)).to.equal(Math.round(c2.lng));
+		});
+		
+		it('Keeps image proportions when scaling', function() {
+			var w = overlay.getElement().getBoundingClientRect().width,
+				h = overlay.getElement().getBoundingClientRect().height;
+
+			overlay.scaleBy(0.5);
+
+			var w2 = overlay.getElement().getBoundingClientRect().width,
+				h2 = overlay.getElement().getBoundingClientRect().height;
+
+			expect(Math.round(w / 2)).to.be.equal(Math.round(w2));
+			expect(Math.round(h / 2)).to.be.equal(Math.round(h2));
+		});
+	});
+
 	describe("#_select", function () {
 		it("It should initialize an image's individual toolbar instance", function () {
 			var edit = overlay.editing,

--- a/test/src/edit/EditHandleSpec.js
+++ b/test/src/edit/EditHandleSpec.js
@@ -3,15 +3,15 @@ describe('L.EditHandle', function() {
 
     beforeEach(function(done) {
         map = L.map(L.DomUtil.create('div', '', document.body))
-               .setView([41.7896, -87.5996], 15);
+               .setView([51.505, -0.09], 13);
 
         overlay = L.distortableImageOverlay('/examples/example.jpg', {
-            corners: [
-                L.latLng(41.7934, -87.6052),
-                L.latLng(41.7934, -87.5852),
-                L.latLng(41.7834, -87.5852),
-                L.latLng(41.7834, -87.6052)
-            ]
+          corners: [
+              L.latLng(51.52, -0.14),
+              L.latLng(51.52, -0.1),
+              L.latLng(51.5, -0.14),
+              L.latLng(51.5, -0.1)
+          ]
         }).addTo(map);
 
         L.DomEvent.on(overlay._image, 'load', function() {
@@ -36,6 +36,17 @@ describe('L.EditHandle', function() {
                 scale = scaleHandle._calculateScalingFactor(latlng, latlng);
 
             expect(scale).to.equal(1);
+        });
+
+        it('Should return a smaller value as the 2nd latlng gets closer to the images original center.', function() {
+            var latlng = overlay.getCorner(0),
+                latlng2 = L.latLng(51.51, -0.13),
+                latlng3 = L.latLng(51.51, -0.12),
+                scale = scaleHandle._calculateScalingFactor(latlng, latlng2);
+                scale2 = scaleHandle._calculateScalingFactor(latlng, latlng3);
+           
+            expect(scale).to.be.below(1);
+            expect(scale2).to.be.below(scale);
         });
     });
 });


### PR DESCRIPTION
Testing for #341, testing  scale and exposing scaleBy API
Fixes #352 
   - #301 
   - #85 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updates
* [ ] @mention the original creator of the issue in a comment below for help or for a review

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!

====================
changes
- below moved to L.DistortableImageOverlay:
    -  `scaleBy`
    - `rotateBy`
    - `_revert`: remove distortions using `project`, remaining bug is img shifts position a little on the map. holding off to try to fix completely in smaller PR bc will involve changes to corner initialization.

- Modes fixed: 
   - `scale`: implement `edgeminwidth`, add tests, expose API
   -  `rotate`: remove distortions using `project`
   - `rotateScale`: remove distortions using `project`, implement `edgeminwidth`
   
 - other API:
- `setCorner` and `setCorners` exposed. 
   - calls to `overlay._reset`, `overlay.fire('update')`, and `overlay.editing._updateToolbarPos` have all been put inside these methods for consistency - we no longer need to make these calls for each separate distortion.
====================