### PR TITLE
#410 - Add generic method for mouse events simulation.

### DIFF
--- a/test/SpecHelper.js
+++ b/test/SpecHelper.js
@@ -2,6 +2,25 @@ beforeEach(function() {
   /* Make expect function available in all tests. */
   window.expect = chai.expect;
 });
+/*
+* Mouse Events is a dictionary of "Events" and their properties.
+* Other events include 'click', 'dblick', 'mouseup', 'mouseover', 'mouseout', 'mousemove'
+* Properties can take in propeties of initMouseEvents().
+ */
+ chai.mouseEvents = {
+  ShiftDown: {
+    type: "mousedown",
+    isShift: true
+  },
+  MouseDown: {
+    type: "mousedown",
+    isShift: false
+  },
+  Click: {
+    type: "click",
+    isShift: false
+  }
+}
 
 /* Chain global testing utilites below to chai*/
 
@@ -34,6 +53,15 @@ chai.simulateClick = function simulateClickFn(el) {
     return el.dispatchEvent(e);
   }
 };
+
+chai.simulateEvent = function simulateEventFn(el, event) {
+  if (document.createEvent) {
+    var e = document.createEvent('MouseEvents');
+    e.initMouseEvent(event.type, true, true, window, 0, 0, 0, 0, 0, false, false, event.isShift, false, 0, null);
+    return el.dispatchEvent(e);
+  }
+};
+
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 

--- a/test/SpecHelper.js
+++ b/test/SpecHelper.js
@@ -5,29 +5,26 @@ beforeEach(function() {
 
 /* Chain global testing utilites below to chai*/
 
-        /*
-	 * Mouse Events is a dictionary of "Events" and their properties. 
-	 * Other events include 'click', 'dblick', 'mouseup', 'mouseover', 'mouseout', 'mousemove'
-	 * Properties can take in properties of initMouseEvents().
-	 */
- 
- chai.mouseEvents = {
+chai.mouseEvents = {
   ShiftMouseDown: {
-    type: "mousedown",
+    type: 'mousedown',
     isShift: true
   },
   MouseDown: {
-    type: "mousedown",
+    type: 'mousedown',
     isShift: false
   },
   Click: {
-    type: "click",
+    type: 'click',
     isShift: false
-  }
+  },
 }
 
-
-
+/*
+ * Mouse Events is a dictionary of "Events" and their properties. 
+ * Other events include 'click', 'dblick', 'mouseup', 'mouseover', 'mouseout', 'mousemove'
+ * Properties can take in properties of initMouseEvents().
+ */
 chai.simulateEvent = function simulateEventFn(el, event) {
   if (document.createEvent) {
     var e = document.createEvent('MouseEvents');

--- a/test/SpecHelper.js
+++ b/test/SpecHelper.js
@@ -28,36 +28,6 @@ beforeEach(function() {
 
 
 
-    /*
-	 * simulate mouse events manually in the DOM on a passed element. 
-	 *   - (Most) useful parameters: 
-	 *      1) type: string - this is for 'mousedown'. Other options include 'click', 'dblick', 'mouseup', 'mouseover', 'mouseout', 'mousemove
-	 *      2) the booleans after the list of 0s simulate the presence (or lack of) the following keys (in order) during the mouse event: 'ctrlKey', 'altKey', 'shiftKey', 'metaKey' 
-	 */
-chai.simulateShiftMousedown = function simulateCommandMousedownFn(el) {
-  if (document.createEvent) {
-    var e = document.createEvent('MouseEvents');
-    e.initMouseEvent('mousedown', true, true, window, 0, 0, 0, 0, 0, false, false, true, false, 0, null);
-    return el.dispatchEvent(e);
-  }
-};
-
-chai.simulateMousedown= function simulateMousedownFn(el) {
-  if (document.createEvent) {
-    var e = document.createEvent('MouseEvents');
-    e.initMouseEvent('mousedown', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-    return el.dispatchEvent(e);
-  }
-};
-
-chai.simulateClick = function simulateClickFn(el) {
-  if (document.createEvent) {
-    var e = document.createEvent('MouseEvents');
-    e.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-    return el.dispatchEvent(e);
-  }
-};
-
 chai.simulateEvent = function simulateEventFn(el, event) {
   if (document.createEvent) {
     var e = document.createEvent('MouseEvents');

--- a/test/SpecHelper.js
+++ b/test/SpecHelper.js
@@ -5,7 +5,7 @@ beforeEach(function() {
 
 /* Chain global testing utilites below to chai*/
 
-    /*
+        /*
 	 * Mouse Events is a dictionary of "Events" and their properties. 
 	 * Other events include 'click', 'dblick', 'mouseup', 'mouseover', 'mouseout', 'mousemove'
 	 * Properties can take in properties of initMouseEvents().

--- a/test/SpecHelper.js
+++ b/test/SpecHelper.js
@@ -2,13 +2,17 @@ beforeEach(function() {
   /* Make expect function available in all tests. */
   window.expect = chai.expect;
 });
-/*
-* Mouse Events is a dictionary of "Events" and their properties.
-* Other events include 'click', 'dblick', 'mouseup', 'mouseover', 'mouseout', 'mousemove'
-* Properties can take in propeties of initMouseEvents().
- */
+
+/* Chain global testing utilites below to chai*/
+
+    /*
+	 * Mouse Events is a dictionary of "Events" and their properties. 
+	 * Other events include 'click', 'dblick', 'mouseup', 'mouseover', 'mouseout', 'mousemove'
+	 * Properties can take in properties of initMouseEvents().
+	 */
+ 
  chai.mouseEvents = {
-  ShiftDown: {
+  ShiftMouseDown: {
     type: "mousedown",
     isShift: true
   },
@@ -22,7 +26,7 @@ beforeEach(function() {
   }
 }
 
-/* Chain global testing utilites below to chai*/
+
 
     /*
 	 * simulate mouse events manually in the DOM on a passed element. 

--- a/test/src/DistortableCollectionSpec.js
+++ b/test/src/DistortableCollectionSpec.js
@@ -63,7 +63,7 @@ describe('L.DistortableCollection', function() {
       var img = overlay.getElement(),
         img2 = overlay2.getElement();
 
-      chai.simulateEvent(img, chai.mouseEvents.ShiftDown);
+      chai.simulateEvent(img, chai.mouseEvents.ShiftMouseDown);
       chai.simulateEvent(img2, chai.mouseEvents.MouseDown);
 
       expect(imgGroup.isSelected(overlay)).to.be.true;
@@ -89,8 +89,8 @@ describe('L.DistortableCollection', function() {
       var img = overlay.getElement(),
         img2 = overlay2.getElement();
 
-      chai.simulateEvent(img, chai.mouseEvents.ShiftDown);
-      chai.simulateEvent(img2, chai.mouseEvents.ShiftDown);
+      chai.simulateEvent(img, chai.mouseEvents.ShiftMouseDown);
+      chai.simulateEvent(img2, chai.mouseEvents.ShiftMouseDown);
 
       expect(L.DomUtil.getClass(img)).to.include('selected');
       expect(L.DomUtil.getClass(img2)).to.include('selected');
@@ -100,7 +100,7 @@ describe('L.DistortableCollection', function() {
       var img = overlay.getElement();
 
       overlay.editing._toggleLock();
-      chai.simulateEvent(img, chai.mouseEvents.ShiftDown);
+      chai.simulateEvent(img, chai.mouseEvents.ShiftMouseDown);
 
       expect(L.DomUtil.getClass(img)).to.include('selected');
     });

--- a/test/src/DistortableCollectionSpec.js
+++ b/test/src/DistortableCollectionSpec.js
@@ -63,8 +63,8 @@ describe('L.DistortableCollection', function() {
       var img = overlay.getElement(),
         img2 = overlay2.getElement();
 
-      chai.simulateShiftMousedown(img);
-      chai.simulateMousedown(img2);
+      chai.simulateEvent(img, chai.mouseEvents.ShiftDown);
+      chai.simulateEvent(img2, chai.mouseEvents.MouseDown);
 
       expect(imgGroup.isSelected(overlay)).to.be.true;
       expect(imgGroup.isSelected(overlay2)).to.be.false;
@@ -76,8 +76,8 @@ describe('L.DistortableCollection', function() {
       var img = overlay.getElement(),
         img2 = overlay2.getElement();
 
-      chai.simulateMousedown(img);
-      chai.simulateMousedown(img2);
+      chai.simulateEvent(img, chai.mouseEvents.MouseDown);
+      chai.simulateEvent(img2, chai.mouseEvents.MouseDown);
 
       expect(imgGroup.isSelected(overlay)).to.be.false;
       expect(imgGroup.isSelected(overlay2)).to.be.false;
@@ -89,8 +89,8 @@ describe('L.DistortableCollection', function() {
       var img = overlay.getElement(),
         img2 = overlay2.getElement();
 
-      chai.simulateShiftMousedown(img);
-      chai.simulateShiftMousedown(img2);
+      chai.simulateEvent(img, chai.mouseEvents.ShiftDown);
+      chai.simulateEvent(img2, chai.mouseEvents.ShiftDown);
 
       expect(L.DomUtil.getClass(img)).to.include('selected');
       expect(L.DomUtil.getClass(img2)).to.include('selected');
@@ -100,7 +100,7 @@ describe('L.DistortableCollection', function() {
       var img = overlay.getElement();
 
       overlay.editing._toggleLock();
-      chai.simulateShiftMousedown(img);
+      chai.simulateEvent(img, chai.mouseEvents.ShiftDown);
 
       expect(L.DomUtil.getClass(img)).to.include('selected');
     });

--- a/test/src/edit/DistortableCollectionEditSpec.js
+++ b/test/src/edit/DistortableCollectionEditSpec.js
@@ -123,8 +123,7 @@ describe('L.DistortableCollection.Edit', function () {
             expect(map._toolbars).to.be.empty;
 
             // need both bc simulated `mousedown`s don't fire `click` events afterwards like regular user generated `mousedown`s.
-            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
-            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftMouseDown);
             chai.simulateEvent(overlay.getElement(), chai.mouseEvents.Click);
 
             expect(Object.keys(map._toolbars)).to.have.lengthOf(1);
@@ -152,7 +151,7 @@ describe('L.DistortableCollection.Edit', function () {
     describe('#_removeToolbar', function () {
 
         beforeEach(function () { // multi-select the image and add the toolbar
-            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftMouseDown);
             imgGroup.editing._addToolbar();
 
             expect(Object.keys(map._toolbars)).to.have.lengthOf(1);
@@ -167,7 +166,7 @@ describe('L.DistortableCollection.Edit', function () {
 
         it('is invoked on command + mousedown when it toggles the image *out* of multi-select', function () {
             // deselecting the image removes the control toolbar
-            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftMouseDown);
             expect(map._toolbars).to.be.empty;
         });
 
@@ -185,8 +184,8 @@ describe('L.DistortableCollection.Edit', function () {
     describe('#_lockGroup', function() {
 
         beforeEach(function () {
-            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
-            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftMouseDown);
+            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftMouseDown);
             
             imgGroup.editing._lockGroup();
         });
@@ -214,9 +213,9 @@ describe('L.DistortableCollection.Edit', function () {
     describe('#_unlockGroup', function() {
 
         beforeEach(function () {
-            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
-            chai.simulateEvent(overlay2.getElement(), chai.mouseEvents.ShiftDown);
-            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftMouseDown);
+            chai.simulateEvent(overlay2.getElement(), chai.mouseEvents.ShiftMouseDown);
+            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftMouseDown);
 
             imgGroup.editing._lockGroup();
             expect(overlay.editing._mode).to.equal('lock');
@@ -237,8 +236,8 @@ describe('L.DistortableCollection.Edit', function () {
     describe('#_removeGroup', function () {
         
         beforeEach(function() { // multi-selects the images to add them to the feature group
-            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
-            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftMouseDown);
+            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftMouseDown);
         });
 
         it('removes a collection of layers that are multi-selected', function () {

--- a/test/src/edit/DistortableCollectionEditSpec.js
+++ b/test/src/edit/DistortableCollectionEditSpec.js
@@ -102,8 +102,8 @@ describe('L.DistortableCollection.Edit', function () {
         edit2._toggleLock();
 
         // select both images to initially create individual toolbar instances (single selection interface)
-        chai.simulateClick(overlay.getElement());
-        chai.simulateClick(overlay2.getElement());
+        chai.simulateEvent(overlay.getElement(), chai.mouseEvents.Click);
+        chai.simulateEvent(overlay2.getElement(), chai.mouseEvents.Click);
 
         expect(edit.toolbar).to.not.be.false;
         expect(edit2.toolbar).to.not.be.false;
@@ -123,8 +123,9 @@ describe('L.DistortableCollection.Edit', function () {
             expect(map._toolbars).to.be.empty;
 
             // need both bc simulated `mousedown`s don't fire `click` events afterwards like regular user generated `mousedown`s.
-            chai.simulateShiftMousedown(overlay.getElement());
-            chai.simulateClick(overlay.getElement());
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.Click);
 
             expect(Object.keys(map._toolbars)).to.have.lengthOf(1);
         });
@@ -151,7 +152,7 @@ describe('L.DistortableCollection.Edit', function () {
     describe('#_removeToolbar', function () {
 
         beforeEach(function () { // multi-select the image and add the toolbar
-            chai.simulateShiftMousedown(overlay.getElement());
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
             imgGroup.editing._addToolbar();
 
             expect(Object.keys(map._toolbars)).to.have.lengthOf(1);
@@ -166,7 +167,7 @@ describe('L.DistortableCollection.Edit', function () {
 
         it('is invoked on command + mousedown when it toggles the image *out* of multi-select', function () {
             // deselecting the image removes the control toolbar
-            chai.simulateShiftMousedown(overlay.getElement());
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
             expect(map._toolbars).to.be.empty;
         });
 
@@ -184,8 +185,8 @@ describe('L.DistortableCollection.Edit', function () {
     describe('#_lockGroup', function() {
 
         beforeEach(function () {
-            chai.simulateShiftMousedown(overlay.getElement());
-            chai.simulateShiftMousedown(overlay3.getElement());
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftDown);
             
             imgGroup.editing._lockGroup();
         });
@@ -213,9 +214,9 @@ describe('L.DistortableCollection.Edit', function () {
     describe('#_unlockGroup', function() {
 
         beforeEach(function () {
-            chai.simulateShiftMousedown(overlay.getElement());
-            chai.simulateShiftMousedown(overlay2.getElement());
-            chai.simulateShiftMousedown(overlay3.getElement());
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay2.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftDown);
 
             imgGroup.editing._lockGroup();
             expect(overlay.editing._mode).to.equal('lock');
@@ -236,8 +237,8 @@ describe('L.DistortableCollection.Edit', function () {
     describe('#_removeGroup', function () {
         
         beforeEach(function() { // multi-selects the images to add them to the feature group
-            chai.simulateShiftMousedown(overlay.getElement());
-            chai.simulateShiftMousedown(overlay3.getElement());
+            chai.simulateEvent(overlay.getElement(), chai.mouseEvents.ShiftDown);
+            chai.simulateEvent(overlay3.getElement(), chai.mouseEvents.ShiftDown);
         });
 
         it('removes a collection of layers that are multi-selected', function () {

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -35,7 +35,7 @@ describe('L.DistortableImage.Edit', function() {
 
     edit.enable();
     // this test applies to a selected image
-    chai.simulateClick(img);
+    chai.simulateEvent(img, chai.mouseEvents.Click);
 
     overlay.setCorner(0, L.latLng(41.7934, -87.6252));
 
@@ -94,7 +94,7 @@ describe('L.DistortableImage.Edit', function() {
 			// switch to lock handles
 			edit._toggleLock();
 			// select the image to initially create its individual toolbar instance
-			chai.simulateClick(img);
+			chai.simulateEvent(img, chai.mouseEvents.Click);
 
 			expect(edit.toolbar).to.not.be.false
 


### PR DESCRIPTION
Fixes #410 

* [✅] PR is descriptively titled 📑 and links the original issue above 🔗
* [✅ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt`
* [ ✅] code is in uniquely-named feature branch and has no merge conflicts 📁
* [✅ ] screenshots/GIFs are attached 📎 in case of UI updates - Not applcable
* [✅ ] @mention the original creator of the issue in a comment below for help or for a review
@rexagod 

Adds generic method which takes in the event and provides the corresponding properties where ever required. 

Thanks!
