### PR TITLE
Tapevents

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,6 +136,8 @@ module.exports = function(grunt) {
           'src/edit/DistortableImage.Edit.js',
           'src/edit/DistortableCollection.Edit.js',
           'src/components/DistortableImage.Keymapper.js',
+          'src/mapmixins/MapMixins.js',
+          'src/mapmixins/DoubleClickZoom.js',
           'src/mapmixins/*.js'
         ],
         dest: 'dist/leaflet.distortableimage.js'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,7 +136,6 @@ module.exports = function(grunt) {
           'src/edit/DistortableImage.Edit.js',
           'src/edit/DistortableCollection.Edit.js',
           'src/components/DistortableImage.Keymapper.js',
-          'src/mapmixins/MapMixins.js',
           'src/mapmixins/DoubleClickZoom.js',
           'src/mapmixins/*.js'
         ],

--- a/README.md
+++ b/README.md
@@ -439,10 +439,13 @@ We have made changes to a default Leaflet handler:
 <details><summary><code><b>doubleClickZoom</b>: this</code></summary>
 <ul>
   <li>This handler may not be <code>enabled</code> (and will return false) while the <code>doubleClickLabels</code> handler is <code>enabled</code>.</li>  
-  <li>This handler and <code>doubleClickLabels</code> time and fire a custom <code>singleclick</code> event on map click. It is fired after a 3ms timeout if the click doesn't become a doubleclick.</li>
-  <li>This allows our images to remain selected during associated double click events on the map (in this case zooming).</li>
+  <li>This handler and <code>doubleClickLabels</code> time and fire a custom <code>singleclick</code> event on map click.</li>
 </ul>
 </details>
+
+<br>
+
+<blockquote>Our "doubleClick" handlers mentioned above use a custom <strong><code>singleclick</code></strong> event to run logic on map <code>dblclick</code> while allowing the images on the map to remain <code>selected</code>. You can read more about the implications of this and how to disable it on our wiki <a href="https://github.com/publiclab/Leaflet.DistortableImage/wiki/The-singleclick-event">"The singleclick event"</a>.</blockquote>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ We have slightly changed a default Leaflet handler:
 
 <br>
 
-<blockquote>Our "doubleClick" handlers mentioned above use a custom <strong><code>singleclick</code></strong> event to run logic on map <code>dblclick</code> while allowing the images on the map to remain <code>selected</code>. You can read more about the implications of this and how to disable it on our wiki <a href="https://github.com/publiclab/Leaflet.DistortableImage/wiki/The-singleclick-event">"The singleclick event"</a>.</blockquote>
+<blockquote>Our "doubleClick" handlers mentioned above use a custom <strong><code>singleclick</code></strong> event to run logic on map <code>dblclick</code> while allowing the images on the map to remain <code>selected</code>. You can read more about the implications of this and how to disable it on our wiki <a href="https://github.com/publiclab/Leaflet.DistortableImage/wiki/The-singleclick-event">"singleclick event"</a>.</blockquote>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ And the following custom handlers:
   </ul>
 </details>
 <br>
-We have made changes to a default Leaflet handler:
+We have slightly changed a default Leaflet handler:
 <br><br>
 <details><summary><code><b>doubleClickZoom</b>: this</code></summary>
 <ul>

--- a/README.md
+++ b/README.md
@@ -377,32 +377,38 @@ We have extended Leaflet's `L.Map` to include a convenience method for this libr
 <details><summary><code><b>addGoogleMutant(<i>opts?</i> &#60;Mutant options>)</b>: this</code></summary>
   <ul>
     <li>Adds a Google Mutant layer with location labels according to our recommended setup.</li>
-    <li>Label visibility is toggled by double clicking on the map.</li>
-    <li><b>Mutant options</b>: {
+    <li><code><b>Mutant options: {[mutantOpacity][, maxZoom][, minZoom][, labels][, labelOpacity][, doubleClickLabels]}</b></code>
       <ul>
-        <li><i>labels</i>: &#60;boolean>, default: true</li>
+        <li><code>mutantOpacity</code> (default 0.8, value: <i>number 0..1</i>)</li>
         <ul>
-          <li>If set to <code>false</code>, the mutant layer will not have location labels</li>
+          <li>Same as Leaflet's <code>L.TileLayer</code> <code>opacity</code> option.</li>
         </ul>
-        <li><i>labelOpacity</i>: &#60;number 0, 1>, default: 0</li>
-        <ul>
-          <li>If set to <code>1</code>, labels will be initially visible</li>
-        </ul>
-        <li><i>mutantOpacity</i>: &#60;number 0..1>, default: 0.8</li>
-        <ul>
-          <li>Same as Leaflet's <code>L.TileLayer</code> <code>opacity</code> option</li>
-        </ul>
-        <li><i>maxZoom</i>: &#60;number 0..21>, default: 18</li>
+        <li><code>maxZoom</code> (default: 18, value: <i>number 0..21</i>)</li>
         <ul>
           <li>Same as Leaflet's <code>L.TileLayer</code> <code>maxZoom</code> option, except has a maximum value of 21 because higher zoom levels on the mutant layer will result in an error being thrown.</li>
           <li>The mutant layer will appear blurry for zoom levels exceeding 18.</li>
         </ul>
-        <li><i>minZoom</i>: &#60;number 0..maxZoom>, default: 0</li>
+        <li><code>minZoom</code> (default: 0, value: <i>number 0..maxZoom</i>)</li>
         <ul>
-          <li>Same as Leaflet's <code>L.TileLayer</code> <code>maxZoom</code> option</li>
+          <li>Same as Leaflet's <code>L.TileLayer</code> <code>minZoom</code> option.</li>
+        </ul>
+        <li><code>labels</code> (default: true, value: <i>boolean</i>)</li>
+        <ul>
+          <li>If set to <code>false</code>, the mutant layer will not have location labels.</li>
+        </ul>
+        <li><code>labelOpacity</code> (default: 1, value: <i>number 0, 1</i>)</li>
+        <ul>
+          <li>If set to <code>0</code>, labels will be initially invisible.</li>
+          <li>Set to <code>undefined</code> if <code>labels: false</code> is also passed.</li>
+        </ul>
+        <li><code>doubleClickLabels</code> (default: true, value: <i>boolean</i>)</li>
+        <ul>
+          <li>Label visibility (opacity) is toggled between 0 and 1 on map <code>dblclick</code>. To turn this functionality off, set this option to false.</li>
+          <li>Set to <code>false</code> if <code>labels: false</code> is also passed.</li>
         </ul>
       </ul>
-    }</li>
+    </li>
+    <li>Mutant options are saved on the map and accessible during runtime as <code>map.mutantOptions.</code></li>
   </ul>
 </details>
 <br>
@@ -411,9 +417,10 @@ And the following custom handlers:
 
 <details><summary><code><b>doubleClickLabels</b>: this</code></summary>
   <ul>
-    <li>When location labels are added via <code>#addGoogleMutant</code>, this handler is enabled by default to allow toggling their visibility by double clicking on the map.</li>
-    <li>Afterwards, can be enabled / disabled during runtime via <a href="https://leafletjs.com/reference-1.5.0.html#handler">Leaflet's Handler API</a>.</li>
-    <li>Overrides the map's default <a href="https://leafletjs.com/reference-1.5.0.html#map-doubleclickzoom"><code>doubleClickZoom</code></a> handler when enabled. When disabled, automatically re-enables it.</li>
+    <li>Enabled by default on <code>#addGoogleMutant</code> unless the options <code>labels: false</code> or <code>doubleClickLabels: false</code> are passed to it.</li>
+    <li>Allows toggling label visibility on map <code>dblclick</code>.</li>
+    <li>Can always be enabled/disabled during runtime via <a href="https://leafletjs.com/reference-1.5.0.html#handler">Leaflet's Handler API</a>.</li>
+    <li>Disables the map's default <a href="https://leafletjs.com/reference-1.5.0.html#map-doubleclickzoom"><code>doubleClickZoom</code></a> handler when enabled.</li>
   </ul>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -434,10 +434,11 @@ And the following custom handlers:
   </ul>
 </details>
 <br>
-We have made slight changes to a default Leaflet handler:
+We have made changes to a default Leaflet handler:
 <br><br>
 <details><summary><code><b>doubleClickZoom</b>: this</code></summary>
 <ul>
+  <li>This handler may not be <code>enabled</code> (and will return false) while the <code>doubleClickLabels</code> handler is <code>enabled</code>.</li>  
   <li>This handler and <code>doubleClickLabels</code> time and fire a custom <code>singleclick</code> event on map click. It is fired after a 3ms timeout if the click doesn't become a doubleclick.</li>
   <li>This allows our images to remain selected during associated double click events on the map (in this case zooming).</li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ We have extended Leaflet's `L.Map` to include a convenience method for this libr
         <li><code>doubleClickLabels</code> (default: true, value: <i>boolean</i>)</li>
         <ul>
           <li>Label visibility (opacity) is toggled between 0 and 1 on map <code>dblclick</code>. To turn this functionality off, set this option to false.</li>
-          <li>Set to <code>false</code> if <code>labels: false</code> is also passed.</li>
+          <li>Set to <code>undefined</code> if <code>labels: false</code> is also passed.</li>
         </ul>
       </ul>
     </li>
@@ -417,9 +417,12 @@ And the following custom handlers:
 
 <details><summary><code><b>doubleClickLabels</b>: this</code></summary>
   <ul>
-    <li>Enabled by default on <code>#addGoogleMutant</code> unless the options <code>labels: false</code> or <code>doubleClickLabels: false</code> are passed to it.</li>
     <li>Allows toggling label visibility on map <code>dblclick</code>.</li>
-    <li>Can always be enabled/disabled during runtime via <a href="https://leafletjs.com/reference-1.5.0.html#handler">Leaflet's Handler API</a>.</li>
+    <li>Enabled by default on <code>#addGoogleMutant</code> unless the options <code>labels: false</code> or <code>doubleClickLabels: false</code> are passed to it.</li>
+    <ul>
+      <li>If <code>labels: false</code> passed, removed from map altogether.</li>
+      <li>If there are labels present but <code>doubleClickLabels: false</code> was passed, just disabled and can always be enabled during runtime via <a href="https://leafletjs.com/reference-1.5.0.html#handler">Leaflet's Handler API</a>.</li>
+    </ul>
     <li>Disables the map's default <a href="https://leafletjs.com/reference-1.5.0.html#map-doubleclickzoom"><code>doubleClickZoom</code></a> handler when enabled.</li>
   </ul>
 </details>

--- a/debug/pixelorigin.html
+++ b/debug/pixelorigin.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=no">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Pixel Origin View For Development</title>
   <script src="../node_modules/leaflet/dist/leaflet-src.js" type="text/javascript" charset="utf-8"></script>

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -3213,14 +3213,14 @@ L.Map.mergeOptions({
 
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
   addHooks: function() {
-    L.DomEvent.on(this._map, {
+    this._map.on({
       click: this._fireIfSingle,
       dblclick: this._onDoubleClick,
     }, this);
   },
 
   removeHooks: function() {
-    L.DomEvent.off(this._map, {
+    this._map.off({
       click: this._fireIfSingle,
       dblclick: this._onDoubleClick,
     }, this);

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -259,8 +259,6 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     this._map = map;
     if (!this._image) { L.ImageOverlay.prototype._initImage.call(this); }
 
-    this.getPane().appendChild(this._image);
-
     map.on('viewreset', this._reset, this);
 
     if (this.options.corners) {
@@ -268,15 +266,11 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
       if (map.options.zoomAnimation && L.Browser.any3d) {
         map.on('zoomanim', this._animateZoom, this);
       }
-
-      /* This reset happens before image load; it allows us to place the
-       * image on the map earlier with "guessed" dimensions.
-       */
-      this._reset();
     }
 
     // Have to wait for the image to load because need to access its w/h
     L.DomEvent.on(this._image, 'load', function() {
+      this.getPane().appendChild(this._image);
       this._initImageDimensions();
       this._reset();
       /* Initialize default corners if not already set */
@@ -296,14 +290,13 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
       }
     }, this);
 
-    this.fire('add');
-
     L.DomEvent.on(this._image, 'click', this.select, this);
     L.DomEvent.on(map, {
       singleclickon: this._singleClickListeners,
       singleclickoff: this._resetClickListeners,
       singleclick: this._singleClick,
     }, this);
+
     /**
      * custom events fired from DoubleClickLabels.js. Used to differentiate
      * single / dblclick to not deselect images on map dblclick.
@@ -3260,7 +3253,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
         map.fire('singleclick', {type: 'singleclick'});
       } else {
         // manually fire doubleclick event only for touch screens
-        if (L.Browser.touch) {
+        if (L.Browser.touch && L.Browser.chrome) {
           if (!L.Browser.pointer) {
             map.fire('dblclick');
           } else if (oe && oe.sourceCapabilities.firesTouchEvents) {

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -1431,7 +1431,9 @@ L.EditAction = L.Toolbar2.Action.extend({
 
     if (className) {
       L.DomUtil.addClass(this._link, className);
-      if (className === 'disabled') { L.DomUtil.addClass(this._icon, className); }
+      if (className === 'disabled') {
+        L.DomUtil.addClass(this._icon, className);
+      }
       if (className === edit._mode) {
         L.DomUtil.addClass(this._link, 'selected-mode');
       } else {
@@ -3309,8 +3311,8 @@ L.Map.mergeOptions({
 });
 
 /**
- * The 'doubleClickLabels' handler only runs instead of 'doubleClickZoom' when a googleMutant
- * layer is added to the map using 'map.addGoogleMutant()' without the option labels: false.
+ * The 'doubleClickLabels' handler replaces 'doubleClickZoom' by default when #addGoogleMutant is used
+ * unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
  */
 
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
@@ -3319,7 +3321,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
 
     if (this._enabled) { return this; }
 
-    // disable 'doubleClickZoom' if 'doubleClickLabels' is enabled.
+    // disable 'doubleClickZoom' if enabling 'doubleClickLabels'
     if (map.doubleClickZoom.enabled()) {
       map.doubleClickZoom.disable();
     }

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -3323,11 +3323,8 @@ L.Map.include({
     }).addTo(this);
 
     if (opts.labels) { this._addLabels(opts); }
-    // disables and removes from map - shouldn't have this handler at all if there
-    // are no labels to toggle
+    // shouldn't have this handler at all if there are no labels to toggle
     else {
-      // this.doubleClickLabels.disable();
-      // this.doubleClickZoom.enable();
       this.doubleClickLabels = undefined;
     }
 
@@ -3351,16 +3348,15 @@ L.Map.include({
       ext: 'png',
     }).addTo(this);
 
-    // disables but keeps on map (can re-enable)
     if (this.mutantOptions.doubleClickLabels) {
       this.doubleClickLabels.enable();
-      // this.doubleClickZoom.enable();
     }
 
     return this;
   },
 });
-
+// start off with doubleClickZoom enabled, doubleClickLabels can later be enabled instead
+// during initialization
 L.Map.addInitHook(function() {
   this.doubleClickLabels.disable();
   this.doubleClickZoom.enable();

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -3301,8 +3301,6 @@ L.Map.addInitHook('addHandler', 'doubleClickLabels', L.Map.DoubleClickLabels);
 /* eslint-disable max-len */
 L.Map.include({
 
-  _singleClickTimeout: null,
-
   _clicked: 0,
 
   addGoogleMutant: function(opts) {
@@ -3368,37 +3366,5 @@ L.Map.include({
     }
 
     return this;
-  },
-
-  _fireDOMEventNoPreclick: function(e, type, targets) {
-    if (e._stopped) { return; }
-
-    // Find the layer the event is propagating from and its parents.
-    targets = (targets || []).concat(this._findEventTargets(e, type));
-
-    if (!targets.length) { return; }
-
-    var target = targets[0];
-    if (type === 'contextmenu' && target.listens(type, true)) {
-      L.DomEvent.preventDefault(e);
-    }
-
-    var data = {
-      originalEvent: e,
-    };
-
-    if (e.type !== 'keypress' && e.type !== 'keydown' && e.type !== 'keyup') {
-      var isMarker = target.getLatLng && (!target._radius || target._radius <= 10);
-      data.containerPoint = isMarker ?
-        this.latLngToContainerPoint(target.getLatLng()) : this.mouseEventToContainerPoint(e);
-      data.layerPoint = this.containerPointToLayerPoint(data.containerPoint);
-      data.latlng = isMarker ? target.getLatLng() : this.layerPointToLatLng(data.layerPoint);
-    }
-
-    for (var i = 0; i < targets.length; i++) {
-      targets[i].fire(type, data, true);
-      if (data.originalEvent._stopped ||
-        (targets[i].options.bubblingMouseEvents === false && L.Util.indexOf(this._mouseEvents, type) !== -1)) { return; }
-    }
   },
 });

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -2488,7 +2488,7 @@ L.DistortableImage.Edit = L.Handler.extend({
           this._overlay.select();
         }
       }
-      // L.DomEvent.stop(e);
+      L.DomEvent.stop(e);
     }
 
     return this.setMode(newMode);

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -52,6 +52,13 @@ L.DomUtil = L.extend(L.DomUtil, {
     return window.confirm('Are you sure? ' + n +
     ' ' + humanized + ' will be permanently deleted from the map.');
   },
+
+  browserFiresNativeDblClick: function(e) {
+    // See https://github.com/w3c/pointerevents/issues/171
+    // Note however, that Chrome stopped firing native dblclick for
+    // touch since that issue was written.
+    return (L.Browser.ie || e.pointerType === 'mouse');
+  },
 });
 
 L.IconUtil = {
@@ -3020,12 +3027,10 @@ L.Map.DoubleClickZoom.include({
       } else {
         // manually fire doubleclick event only for touch screens
         if (L.Browser.touch) {
-          if (!L.Browser.pointer) {
+          if (oe && oe.sourceCapabilities.firesTouchEvents) {
             // in `DoubleClickLabels.js`, we just do map.fire('dblclick') bc `_onDoublClick` doesn't use the
             // passed "e" (for now). To generate a 'real' DOM event that will have all of its corresponding core
             // properties (originalEvent, latlng, etc.), use Leaflet's `#map._fireDOMEvent` (Leaflet 1.5.1 source)
-            map._fireDOMEvent(oe, 'dblclick', [map]);
-          } else if (oe && oe.sourceCapabilities.firesTouchEvents) {
             map._fireDOMEvent(oe, 'dblclick', [map]);
           }
         }
@@ -3253,10 +3258,8 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
         map.fire('singleclick', {type: 'singleclick'});
       } else {
         // manually fire doubleclick event only for touch screens
-        if (L.Browser.touch && L.Browser.chrome) {
-          if (!L.Browser.pointer) {
-            map.fire('dblclick');
-          } else if (oe && oe.sourceCapabilities.firesTouchEvents) {
+        if (L.Browser.touch) {
+          if (oe && oe.sourceCapabilities.firesTouchEvents) {
             map.fire('dblclick');
           }
         }

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -2964,7 +2964,7 @@ L.distortableImage.keymapper = function(map, options) {
 
 /**
  * `L.Map.DoubleClickZoom` from leaflet 1.5.1, overrwritten so that it
- * 1)fires a `singleclick` event to avoid deselecting images on `dblclick`.
+ * 1) Fires a `singleclick` event to avoid deselecting images on `dblclick`.
  * 2) Maintains a mutually exclusive relationship with the map's `DoubleClickLabels` handler
  */
 
@@ -3025,7 +3025,7 @@ L.Map.DoubleClickZoom.include({
         map._clicked = 0;
         map.fire('singleclick', {type: 'singleclick'});
       } else {
-        // manually fire doubleclick event only for touch screens
+        // manually fire doubleclick event only for touch screens that don't natively fire it
         if (L.Browser.touch) {
           if (oe && oe.sourceCapabilities.firesTouchEvents) {
             // in `DoubleClickLabels.js`, we just do map.fire('dblclick') bc `_onDoublClick` doesn't use the
@@ -3257,7 +3257,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
         map._clicked = 0;
         map.fire('singleclick', {type: 'singleclick'});
       } else {
-        // manually fire doubleclick event only for touch screens
+        // manually fire doubleclick event only for touch screens that don't natively fire it
         if (L.Browser.touch) {
           if (oe && oe.sourceCapabilities.firesTouchEvents) {
             map.fire('dblclick');
@@ -3275,6 +3275,8 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
       map._clicked = 0;
       clearTimeout(map._clickTimeout);
     }, 0);
+
+    if (!labels) { return; }
 
     if (labels.options.opacity === 1) {
       labels.options.opacity = 0;
@@ -3324,8 +3326,8 @@ L.Map.include({
     // disables and removes from map - shouldn't have this handler at all if there
     // are no labels to toggle
     else {
-      this.doubleClickLabels.disable();
-      this.doubleClickZoom.enable();
+      // this.doubleClickLabels.disable();
+      // this.doubleClickZoom.enable();
       this.doubleClickLabels = undefined;
     }
 
@@ -3350,11 +3352,16 @@ L.Map.include({
     }).addTo(this);
 
     // disables but keeps on map (can re-enable)
-    if (!this.mutantOptions.doubleClickLabels) {
-      this.doubleClickLabels.disable();
-      this.doubleClickZoom.enable();
+    if (this.mutantOptions.doubleClickLabels) {
+      this.doubleClickLabels.enable();
+      // this.doubleClickZoom.enable();
     }
 
     return this;
   },
+});
+
+L.Map.addInitHook(function() {
+  this.doubleClickLabels.disable();
+  this.doubleClickZoom.enable();
 });

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -1074,29 +1074,24 @@ L.EditHandle = L.Marker.extend({
   },
 
   _bindListeners: function() {
-    this.on(
-        {
-          dragstart: this._onHandleDragStart,
-          drag: this._onHandleDrag,
-          dragend: this._onHandleDragEnd,
-        },
-        this
-    );
+    this.on({
+      contextmenu: L.DomEvent.stop,
+      dragstart: this._onHandleDragStart,
+      drag: this._onHandleDrag,
+      dragend: this._onHandleDragEnd,
+    }, this);
 
     this._handled._map.on('zoomend', this.updateHandle, this);
-
     this._handled.on('update', this.updateHandle, this);
   },
 
   _unbindListeners: function() {
-    this.off(
-        {
-          dragstart: this._onHandleDragStart,
-          drag: this._onHandleDrag,
-          dragend: this._onHandleDragEnd,
-        },
-        this
-    );
+    this.off({
+      contextmenu: L.DomEvent.stop,
+      dragstart: this._onHandleDragStart,
+      drag: this._onHandleDrag,
+      dragend: this._onHandleDragEnd,
+    }, this);
 
     this._handled._map.off('zoomend', this.updateHandle, this);
     this._handled.off('update', this.updateHandle, this);
@@ -1116,8 +1111,7 @@ L.EditHandle = L.Marker.extend({
     return Math.sqrt(newRadiusSquared / formerRadiusSquared);
   },
 
-  /* Distance between two points in cartesian space,
-  * squared (distance formula). */
+  /* Distance between two points in cartesian space, squared (distance formula). */
   _d2: function(a, b) {
     var dx = a.x - b.x;
     var dy = a.y - b.y;
@@ -1134,12 +1128,12 @@ L.EditHandle = L.Marker.extend({
     var formerPoint = map.latLngToLayerPoint(latlngA);
     var newPoint = map.latLngToLayerPoint(latlngB);
 
-    var initialAngle = Math.
-        atan2(
-            centerPoint.y - formerPoint.y, centerPoint.x - formerPoint.x);
-    var newAngle = Math.
-        atan2(
-            centerPoint.y - newPoint.y, centerPoint.x - newPoint.x);
+    var initialAngle = (
+      Math.atan2(centerPoint.y - formerPoint.y, centerPoint.x - formerPoint.x)
+    );
+    var newAngle = (
+      Math.atan2(centerPoint.y - newPoint.y, centerPoint.x - newPoint.x)
+    );
 
     return newAngle - initialAngle;
   },

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -3244,7 +3244,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
     }, 250);
   },
 
-  _onDoubleClick: function(e) {
+  _onDoubleClick: function() {
     var map = this._map;
     var labels = map._labels;
 

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -3135,9 +3135,9 @@ L.Map.DoubleClickZoom.include({
     this._singleClickTimeout = setTimeout(function() {
       if (map._clicked === 1) {
         map._clicked = 0;
-        if (eo && !eo._stopped) {
-          map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
-        }
+        // if (eo && !eo._stopped) {
+        map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
+        // }
       }
     }, 250);
   },
@@ -3154,7 +3154,7 @@ L.Map.DoubleClickZoom.include({
 
     map._clicked = 0;
 
-    this._cancelSingleClick();
+    // this._cancelSingleClick();
 
     var oldZoom = map.getZoom();
     var delta = map.options.zoomDelta;
@@ -3345,7 +3345,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
     var map = this._map;
     var labels = map._labels;
 
-    this._cancelSingleClick();
+    // this._cancelSingleClick();
 
     map._clicked = 0;
 

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -3018,7 +3018,7 @@ L.Map.include({
     if (!opts.labels) {
       this.mutantOptions = L.extend(this.mutantOptions, {
         labelOpacity: opts.labels ? 1 : undefined,
-        doubleClickLabels: opts.labels,
+        doubleClickLabels: opts.labels ? true : undefined,
       });
     }
 
@@ -3068,9 +3068,8 @@ L.Map.include({
 });
 
 /**
- * we overrwrite the L.Map.DoubleClickZoom handler so that in case
- * L.Map.DoubleClickLabels is disabled, it will also will fire a `singleclick`
- * event so that images are not deselected on DoubleClickZoom either.
+ * L.Map.DoubleClickZoom from leaflet 1.5.1, overrwritten so that it fires a
+ * `singleclick` event to avoiding deselecting images on doubleclick.
  */
 L.Map.DoubleClickZoom.include({
   addHooks: function() {
@@ -3104,14 +3103,11 @@ L.Map.DoubleClickZoom.include({
     return this;
   },
 
-  /**
-   * if L.Map.DoubleClickZoom is disabled as well, we fire one more custom event
-   * to signify to our collection and instance classes to stop listening for `singleclick`
-   * and start just listening for `click`.
-   */
   disable: function() {
     if (!this._enabled) { return this; }
 
+    // if L.Map.DoubleClickLabels is disabled as well, collection/instance classes
+    // will stop listening for `singleclick` and start just listening for `click`.
     this._map.fire('singleclickoff');
 
     this._enabled = false;
@@ -3311,8 +3307,8 @@ L.Map.mergeOptions({
 });
 
 /**
- * The 'doubleClickLabels' handler replaces 'doubleClickZoom' by default when #addGoogleMutant is used
- * unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
+ * The 'doubleClickLabels' handler replaces 'doubleClickZoom' by default if #addGoogleMutant
+ * is used unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
  */
 
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -257,7 +257,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
 
   onAdd: function(map) {
     this._map = map;
-    if (!this._image) { L.ImageOverlay.prototype._initImage.call(this); }
+    if (!this._image) { this._initImage(); }
 
     map.on('viewreset', this._reset, this);
 

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -2584,11 +2584,13 @@ L.DistortableCollection.Edit = L.Handler.extend({
   _singleClickListeners: function() {
     var map = this._group._map;
     L.DomEvent.off(map, 'click', this._decollectAll, this);
+    L.DomEvent.on(map, 'singleclick', this._decollectAll, this);
   },
 
   _resetClickListeners: function() {
     var map = this._group._map;
     L.DomEvent.on(map, 'click', this._decollectAll, this);
+    L.DomEvent.off(map, 'singleclick', this._decollectAll, this);
   },
 
   _decollectAll: function(e) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -37,7 +37,7 @@
       map = L.map('map').setView([51.505, -0.09], 13);
       map.addGoogleMutant();
 
-      map.whenReady(function () {
+      map.whenReady(function() {
         img = L.distortableImageOverlay('example.jpg', {
           selected: true,
           fullResolutionSrc: 'large.jpg',

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Leaflet.DistortableImage Example</title>
     <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
 
     <script src="../node_modules/leaflet/dist/leaflet.js" type="text/javascript" charset="utf-8"></script>

--- a/examples/listeners.html
+++ b/examples/listeners.html
@@ -3,7 +3,7 @@
 <head>
   <title>Leaflet.DistortableImage Example</title>
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=no"/>
   <meta http-equiv="x-ua-compatible" content="ie=edge"/>
 
   <script src="../node_modules/leaflet/dist/leaflet-src.js" type="text/javascript" charset="utf-8"></script>

--- a/examples/select.html
+++ b/examples/select.html
@@ -3,7 +3,7 @@
 <head>
   <title>Leaflet.DistortableImage Example</title>
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=no"/>
   <meta http-equiv="x-ua-compatible" content="ie=edge"/>
 
   <script src="../node_modules/leaflet/dist/leaflet-src.js" type="text/javascript" charset="utf-8"></script>

--- a/examples/select.html
+++ b/examples/select.html
@@ -36,7 +36,7 @@
 
     (function(){
 
-      map = L.map('map').setView([51.505, -0.09], 13);
+      map = L.map('map', {tap: true}).setView([51.505, -0.09], 13);
       map.addGoogleMutant();
 
       map.whenReady(function() {

--- a/examples/select.html
+++ b/examples/select.html
@@ -36,7 +36,7 @@
 
     (function(){
 
-      map = L.map('map', {tap: true}).setView([51.505, -0.09], 13);
+      map = L.map('map').setView([51.505, -0.09], 13);
       map.addGoogleMutant();
 
       map.whenReady(function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-distortableimage",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-distortableimage",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Leaflet plugin enabling image overlays to be distorted, stretched, and warped (built for Public Lab's MapKnitter: http://publiclab.org).",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -24,7 +24,6 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
   onAdd: function(map) {
     this._map = map;
     if (!this._image) { L.ImageOverlay.prototype._initImage.call(this); }
-    if (!this._events) { this._initEvents(); }
 
     this.getPane().appendChild(this._image);
 
@@ -78,6 +77,8 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     if (!(map.doubleClickZoom.enabled() || map.doubleClickLabels.enabled())) {
       L.DomEvent.on(map, 'click', this.deselect, this);
     }
+
+    this.fire('add');
   },
 
   onRemove: function(map) {
@@ -130,32 +131,24 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     };
   },
 
-  _initEvents: function() {
-    this._events = ['click'];
-
-    for (var i = 0, l = this._events.length; i < l; i++) {
-      L.DomEvent.on(this._image, this._events[i], this._fireMouseEvent, this);
-    }
-  },
-
   /* See src/layer/vector/Path.SVG.js in the Leaflet source. */
-  _fireMouseEvent: function(event) {
-    if (!this.hasEventListeners(event.type)) {
-      return;
-    }
+  // _fireMouseEvent: function(event) {
+  //   if (!this.hasEventListeners(event.type)) {
+  //     return;
+  //   }
 
-    var map = this._map;
-    var containerPoint = map.mouseEventToContainerPoint(event);
-    var layerPoint = map.containerPointToLayerPoint(containerPoint);
-    var latlng = map.layerPointToLatLng(layerPoint);
+  //   var map = this._map;
+  //   var containerPoint = map.mouseEventToContainerPoint(event);
+  //   var layerPoint = map.containerPointToLayerPoint(containerPoint);
+  //   var latlng = map.layerPointToLatLng(layerPoint);
 
-    this.fire(event.type, {
-      latlng: latlng,
-      layerPoint: layerPoint,
-      containerPoint: containerPoint,
-      originalEvent: event,
-    });
-  },
+  //   this.fire(event.type, {
+  //     latlng: latlng,
+  //     layerPoint: layerPoint,
+  //     containerPoint: containerPoint,
+  //     originalEvent: event,
+  //   });
+  // },
 
   _singleClick: function(e) {
     if (e.type === 'singleclick') { this.deselect(); }

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -23,7 +23,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
 
   onAdd: function(map) {
     this._map = map;
-    if (!this._image) { L.ImageOverlay.prototype._initImage.call(this); }
+    if (!this._image) { this._initImage(); }
 
     map.on('viewreset', this._reset, this);
 

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -131,25 +131,6 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     };
   },
 
-  /* See src/layer/vector/Path.SVG.js in the Leaflet source. */
-  // _fireMouseEvent: function(event) {
-  //   if (!this.hasEventListeners(event.type)) {
-  //     return;
-  //   }
-
-  //   var map = this._map;
-  //   var containerPoint = map.mouseEventToContainerPoint(event);
-  //   var layerPoint = map.containerPointToLayerPoint(containerPoint);
-  //   var latlng = map.layerPointToLatLng(layerPoint);
-
-  //   this.fire(event.type, {
-  //     latlng: latlng,
-  //     layerPoint: layerPoint,
-  //     containerPoint: containerPoint,
-  //     originalEvent: event,
-  //   });
-  // },
-
   _singleClick: function(e) {
     if (e.type === 'singleclick') { this.deselect(); }
     else { return; }

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -132,11 +132,13 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
   _singleClickListeners: function() {
     var map = this._map;
     L.DomEvent.off(map, 'click', this.deselect, this);
+    L.DomEvent.on(map, 'singleclick', this.deselect, this);
   },
 
   _resetClickListeners: function() {
     var map = this._map;
     L.DomEvent.on(map, 'click', this.deselect, this);
+    L.DomEvent.off(map, 'singleclick', this.deselect, this);
   },
 
   isSelected: function() {

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -25,8 +25,6 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     this._map = map;
     if (!this._image) { L.ImageOverlay.prototype._initImage.call(this); }
 
-    this.getPane().appendChild(this._image);
-
     map.on('viewreset', this._reset, this);
 
     if (this.options.corners) {
@@ -34,15 +32,11 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
       if (map.options.zoomAnimation && L.Browser.any3d) {
         map.on('zoomanim', this._animateZoom, this);
       }
-
-      /* This reset happens before image load; it allows us to place the
-       * image on the map earlier with "guessed" dimensions.
-       */
-      this._reset();
     }
 
     // Have to wait for the image to load because need to access its w/h
     L.DomEvent.on(this._image, 'load', function() {
+      this.getPane().appendChild(this._image);
       this._initImageDimensions();
       this._reset();
       /* Initialize default corners if not already set */
@@ -62,14 +56,13 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
       }
     }, this);
 
-    this.fire('add');
-
     L.DomEvent.on(this._image, 'click', this.select, this);
     L.DomEvent.on(map, {
       singleclickon: this._singleClickListeners,
       singleclickoff: this._resetClickListeners,
       singleclick: this._singleClick,
     }, this);
+
     /**
      * custom events fired from DoubleClickLabels.js. Used to differentiate
      * single / dblclick to not deselect images on map dblclick.

--- a/src/edit/DistortableCollection.Edit.js
+++ b/src/edit/DistortableCollection.Edit.js
@@ -93,13 +93,11 @@ L.DistortableCollection.Edit = L.Handler.extend({
 
   _singleClickListeners: function() {
     var map = this._group._map;
-
     L.DomEvent.off(map, 'click', this._decollectAll, this);
   },
 
   _resetClickListeners: function() {
     var map = this._group._map;
-
     L.DomEvent.on(map, 'click', this._decollectAll, this);
   },
 

--- a/src/edit/DistortableCollection.Edit.js
+++ b/src/edit/DistortableCollection.Edit.js
@@ -94,11 +94,13 @@ L.DistortableCollection.Edit = L.Handler.extend({
   _singleClickListeners: function() {
     var map = this._group._map;
     L.DomEvent.off(map, 'click', this._decollectAll, this);
+    L.DomEvent.on(map, 'singleclick', this._decollectAll, this);
   },
 
   _resetClickListeners: function() {
     var map = this._group._map;
     L.DomEvent.on(map, 'click', this._decollectAll, this);
+    L.DomEvent.off(map, 'singleclick', this._decollectAll, this);
   },
 
   _decollectAll: function(e) {

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -587,7 +587,7 @@ L.DistortableImage.Edit = L.Handler.extend({
           this._overlay.select();
         }
       }
-      // L.DomEvent.stop(e);
+      L.DomEvent.stop(e);
     }
 
     return this.setMode(newMode);

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -587,7 +587,7 @@ L.DistortableImage.Edit = L.Handler.extend({
           this._overlay.select();
         }
       }
-      L.DomEvent.stop(e);
+      // L.DomEvent.stop(e);
     }
 
     return this.setMode(newMode);

--- a/src/edit/actions/EditAction.js
+++ b/src/edit/actions/EditAction.js
@@ -46,7 +46,9 @@ L.EditAction = L.Toolbar2.Action.extend({
 
     if (className) {
       L.DomUtil.addClass(this._link, className);
-      if (className === 'disabled') { L.DomUtil.addClass(this._icon, className); }
+      if (className === 'disabled') {
+        L.DomUtil.addClass(this._icon, className);
+      }
       if (className === edit._mode) {
         L.DomUtil.addClass(this._link, 'selected-mode');
       } else {

--- a/src/edit/handles/EditHandle.js
+++ b/src/edit/handles/EditHandle.js
@@ -45,29 +45,24 @@ L.EditHandle = L.Marker.extend({
   },
 
   _bindListeners: function() {
-    this.on(
-        {
-          dragstart: this._onHandleDragStart,
-          drag: this._onHandleDrag,
-          dragend: this._onHandleDragEnd,
-        },
-        this
-    );
+    this.on({
+      contextmenu: L.DomEvent.stop,
+      dragstart: this._onHandleDragStart,
+      drag: this._onHandleDrag,
+      dragend: this._onHandleDragEnd,
+    }, this);
 
     this._handled._map.on('zoomend', this.updateHandle, this);
-
     this._handled.on('update', this.updateHandle, this);
   },
 
   _unbindListeners: function() {
-    this.off(
-        {
-          dragstart: this._onHandleDragStart,
-          drag: this._onHandleDrag,
-          dragend: this._onHandleDragEnd,
-        },
-        this
-    );
+    this.off({
+      contextmenu: L.DomEvent.stop,
+      dragstart: this._onHandleDragStart,
+      drag: this._onHandleDrag,
+      dragend: this._onHandleDragEnd,
+    }, this);
 
     this._handled._map.off('zoomend', this.updateHandle, this);
     this._handled.off('update', this.updateHandle, this);
@@ -87,8 +82,7 @@ L.EditHandle = L.Marker.extend({
     return Math.sqrt(newRadiusSquared / formerRadiusSquared);
   },
 
-  /* Distance between two points in cartesian space,
-  * squared (distance formula). */
+  /* Distance between two points in cartesian space, squared (distance formula). */
   _d2: function(a, b) {
     var dx = a.x - b.x;
     var dy = a.y - b.y;
@@ -105,12 +99,12 @@ L.EditHandle = L.Marker.extend({
     var formerPoint = map.latLngToLayerPoint(latlngA);
     var newPoint = map.latLngToLayerPoint(latlngB);
 
-    var initialAngle = Math.
-        atan2(
-            centerPoint.y - formerPoint.y, centerPoint.x - formerPoint.x);
-    var newAngle = Math.
-        atan2(
-            centerPoint.y - newPoint.y, centerPoint.x - newPoint.x);
+    var initialAngle = (
+      Math.atan2(centerPoint.y - formerPoint.y, centerPoint.x - formerPoint.x)
+    );
+    var newAngle = (
+      Math.atan2(centerPoint.y - newPoint.y, centerPoint.x - newPoint.x)
+    );
 
     return newAngle - initialAngle;
   },

--- a/src/mapmixins/BoxCollector.js
+++ b/src/mapmixins/BoxCollector.js
@@ -130,4 +130,3 @@ L.Map.BoxCollector = L.Map.BoxZoom.extend({
 });
 
 L.Map.addInitHook('addHandler', 'boxCollector', L.Map.BoxCollector);
-

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -1,5 +1,7 @@
 L.Map.mergeOptions({
   doubleClickLabels: true,
+  tap: true,
+  doubleTap: true,
 });
 
 /**
@@ -7,18 +9,142 @@ L.Map.mergeOptions({
  * is used unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
  */
 
+// L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
+//   // addHooks: function() {
+//   // this._singleClickTimeout = null;
+
+//   //   this._map.on({
+//   //     click: this._scheduleSingleClick,
+//   //     dblclick: this._onDoubleClick,
+//   //   }, this);
+//   // },
+
+//   // removeHooks: function() {
+//   //   this._singleClickTimeout = null;
+
+//   //   this._map.off({
+//   //     click: this._scheduleSingleClick,
+//   //     dblclick: this._onDoubleClick,
+//   //   }, this);
+//   // },
+
+//   enable: function() {
+//     var map = this._map;
+
+//     if (this._enabled) { return this; }
+
+//     // disable 'doubleClickZoom' if enabling 'doubleClickLabels'
+//     if (map.doubleClickZoom.enabled()) {
+//       map.doubleClickZoom.disable();
+//     }
+
+//     // signify to collection/instance classes to listen for 'singleclick'
+//     this._map.fire('singleclickon');
+
+//     this._enabled = true;
+//     this.addHooks();
+//     this.addHooks();
+//     return this;
+//   },
+
+//   disable: function() {
+//     if (!this._enabled) { return this; }
+
+//     this._map.fire('singleclickoff');
+
+//     this._enabled = false;
+//     this.removeHooks();
+
+//     return this;
+//   },
+
+//   // _clearSingleClickTimeout: function() {
+//   //   if (this._singleClickTimeout !== null) {
+//   //     console.log('clearclicktimeout');
+//   //     clearTimeout(this._singleClickTimeout);
+//   //     this._singleClickTimeout = null;
+//   //   }
+//   // },
+
+//   // _scheduleSingleClick: function(e) {
+//   //   var oe = e.originalEvent;
+//   //   var map = this._map;
+
+//   //   // prevents deselection in case of box selector
+//   //   if (oe && oe.shiftKey) { return; }
+
+//   //   console.log('singleclick');
+//   //   this._clearSingleClickTimeout();
+
+//   //   // this._singleClickTimeout = (
+//   //   // setTimeout(L.bind(this._fireSingleClick, e, this), 250)
+//   //   // );
+//   //   this._singleClickTimeout = setTimeout(function() {
+//   //     // if (oe && !oe._stopped) {
+//   //     map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
+//   //     // }
+//   //   }, 250);
+//   // },
+
+//   // _cancelSingleClick: function() {
+//   //   // This timeout is key to workaround an issue where double-click events
+//   //   // are fired in this order on some touch browsers: ['click', 'dblclick', 'click']
+//   //   // instead of ['click', 'click', 'dblclick']
+//   //   setTimeout(L.bind(this._clearSingleClickTimeout, this), 0);
+//   // },
+
+//   _onDoubleClick: function() {
+//     var map = this._map;
+//     var labels = map._labels;
+
+//     console.log('doubleclick');
+
+//     this._cancelSingleClick();
+
+//     if (labels.options.opacity === 1) {
+//       labels.options.opacity = 0;
+//       labels.setOpacity(0);
+//     } else {
+//       labels.options.opacity = 1;
+//       labels.setOpacity(1);
+//     }
+//   },
+// });
+
+// L.Map.addInitHook('addHandler', 'doubleClickLabels', L.Map.DoubleClickLabels);
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
+  addHooks: function() {
+    L.DomEvent.on(this._map, {
+      // pointerdown: this._fireIfSingle,
+      click: this._fireIfSingle,
+      dblclick: this._onDoubleClick,
+    }, this);
+  },
+
+  removeHooks: function() {
+    // this._map.off({
+    //   click: this._fireIfSingle,
+    //   dblclick: this._onDoubleClick,
+    // }, this);
+    L.DomEvent.on(this._map, {
+      // tap: this._fireIfSingle,
+      // pointerdown: this._fireIfSingle,
+      click: this._fireIfSingle,
+      dblclick: this._onDoubleClick,
+    }, this);
+  },
+
   enable: function() {
     var map = this._map;
 
     if (this._enabled) { return this; }
 
-    // disable 'doubleClickZoom' if enabling 'doubleClickLabels'
+    // disable 'doubleClickZoom' if 'doubleClickLabels' is enabled.
     if (map.doubleClickZoom.enabled()) {
       map.doubleClickZoom.disable();
     }
 
-    // signify to collection/instance classes to listen for 'singleclick'
+    // signify to collection/instance classes to re-enable 'singleclick' listeners
     this._map.fire('singleclickon');
 
     this._enabled = true;
@@ -27,23 +153,45 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
   },
 
   disable: function() {
-    if (!this._enabled) { return this; }
+    // var map = this._map;
 
-    this._map.fire('singleclickoff');
+    if (!this._enabled) { return this; }
 
     this._enabled = false;
     this.removeHooks();
 
+    // // enable 'doubleClickZoom' if 'doubleClickLabels' is disabled.
+    // if (!map.doubleClickZoom.enabled()) {
+    //   map.doubleClickZoom.enable();
+    // }
+
     return this;
+  },
+
+  _fireIfSingle: function(e) {
+    var map = this._map;
+    var eo = e.originalEvent;
+
+    // prevents deselection in case of box selector
+    if (eo && eo.shiftKey) { return; }
+
+    map._clicked += 1;
+    this._map._clickTimeout = setTimeout(function() {
+      if (map._clicked === 1) {
+        map._clicked = 0;
+        map.fire('singleclick', {type: 'singleclick'});
+      }
+    }, 250);
   },
 
   _onDoubleClick: function() {
     var map = this._map;
     var labels = map._labels;
 
-    // this._cancelSingleClick();
-
-    map._clicked = 0;
+    setTimeout(function() {
+      map._clicked = 0;
+      clearTimeout(map._clickTimeout);
+    }, 0);
 
     if (labels.options.opacity === 1) {
       labels.options.opacity = 0;
@@ -55,4 +203,91 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
   },
 });
 
+/**
+ * a little repetitive, but here we overrwrite the L.Map.DoubleClickZoom
+ * handler so that in case L.Map.DoubleClickLabels is disabled, this handler
+ * will fire a `singleclick` event that our collection and overlay classes
+ * both listen for. Bonus: now DoubleClickZoom doesn't deselect our images either.
+ */
+L.Map.DoubleClickZoom.include({
+  addHooks: function() {
+    this._map.on({
+      click: this._fireIfSingle,
+      dblclick: this._onDoubleClick,
+    }, this);
+  },
+
+  removeHooks: function() {
+    this._map.off({
+      click: this._fireIfSingle,
+      dblclick: this._onDoubleClick,
+    }, this);
+  },
+
+  enable: function() {
+    if (this._enabled) { return this; }
+
+    // don't enable 'doubleClickZoom' unless 'doubleClickLabels' is disabled first
+    if (this._map.doubleClickLabels) {
+      if (this._map.doubleClickLabels.enabled()) {
+        return this;
+      }
+    }
+
+    this._map.fire('singleclickon');
+
+    this._enabled = true;
+    this.addHooks();
+    return this;
+  },
+
+  /**
+   * if L.Map.DoubleClickZoom is disabled as well, we fire one more custom event
+   * to signify to our collection and instance classes to stop listening for `singleclick`
+   * and start just listening for `click`.
+   */
+  disable: function() {
+    if (!this._enabled) { return this; }
+
+    this._map.fire('singleclickoff');
+
+    this._enabled = false;
+    this.removeHooks();
+    return this;
+  },
+
+  _fireIfSingle: function(e) {
+    var map = this._map;
+    var eo = e.originalEvent;
+
+    // prevents deselection in case of box selector
+    if (eo && eo.shiftKey) { return; }
+
+    map._clicked += 1;
+    setTimeout(function() {
+      if (map._clicked === 1) {
+        map._clicked = 0;
+        map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
+      }
+    }, 250);
+  },
+
+  _onDoubleClick: function(e) {
+    var map = this._map;
+
+    map._clicked = 0;
+
+    var oldZoom = map.getZoom();
+    var delta = map.options.zoomDelta;
+    var zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
+
+    if (map.options.doubleClickZoom === 'center') {
+      map.setZoom(zoom);
+    } else {
+      map.setZoomAround(e.containerPoint, zoom);
+    }
+  },
+});
+
 L.Map.addInitHook('addHandler', 'doubleClickLabels', L.Map.DoubleClickLabels);
+

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -3,8 +3,8 @@ L.Map.mergeOptions({
 });
 
 /**
- * The 'doubleClickLabels' handler only runs instead of 'doubleClickZoom' when a googleMutant
- * layer is added to the map using 'map.addGoogleMutant()' without the option labels: false.
+ * The 'doubleClickLabels' handler replaces 'doubleClickZoom' by default when #addGoogleMutant is used
+ * unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
  */
 
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
@@ -13,7 +13,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
 
     if (this._enabled) { return this; }
 
-    // disable 'doubleClickZoom' if 'doubleClickLabels' is enabled.
+    // disable 'doubleClickZoom' if enabling 'doubleClickLabels'
     if (map.doubleClickZoom.enabled()) {
       map.doubleClickZoom.disable();
     }

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -1,134 +1,22 @@
 L.Map.mergeOptions({
   doubleClickLabels: true,
-  tap: true,
-  doubleTap: true,
 });
 
 /**
- * The 'doubleClickLabels' handler replaces 'doubleClickZoom' by default if #addGoogleMutant
+ * The `doubleClickLabels` handler replaces `doubleClickZoom` by default if `#addGoogleMutant`
  * is used unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
  */
 
-// L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
-//   // addHooks: function() {
-//   // this._singleClickTimeout = null;
-
-//   //   this._map.on({
-//   //     click: this._scheduleSingleClick,
-//   //     dblclick: this._onDoubleClick,
-//   //   }, this);
-//   // },
-
-//   // removeHooks: function() {
-//   //   this._singleClickTimeout = null;
-
-//   //   this._map.off({
-//   //     click: this._scheduleSingleClick,
-//   //     dblclick: this._onDoubleClick,
-//   //   }, this);
-//   // },
-
-//   enable: function() {
-//     var map = this._map;
-
-//     if (this._enabled) { return this; }
-
-//     // disable 'doubleClickZoom' if enabling 'doubleClickLabels'
-//     if (map.doubleClickZoom.enabled()) {
-//       map.doubleClickZoom.disable();
-//     }
-
-//     // signify to collection/instance classes to listen for 'singleclick'
-//     this._map.fire('singleclickon');
-
-//     this._enabled = true;
-//     this.addHooks();
-//     this.addHooks();
-//     return this;
-//   },
-
-//   disable: function() {
-//     if (!this._enabled) { return this; }
-
-//     this._map.fire('singleclickoff');
-
-//     this._enabled = false;
-//     this.removeHooks();
-
-//     return this;
-//   },
-
-//   // _clearSingleClickTimeout: function() {
-//   //   if (this._singleClickTimeout !== null) {
-//   //     console.log('clearclicktimeout');
-//   //     clearTimeout(this._singleClickTimeout);
-//   //     this._singleClickTimeout = null;
-//   //   }
-//   // },
-
-//   // _scheduleSingleClick: function(e) {
-//   //   var oe = e.originalEvent;
-//   //   var map = this._map;
-
-//   //   // prevents deselection in case of box selector
-//   //   if (oe && oe.shiftKey) { return; }
-
-//   //   console.log('singleclick');
-//   //   this._clearSingleClickTimeout();
-
-//   //   // this._singleClickTimeout = (
-//   //   // setTimeout(L.bind(this._fireSingleClick, e, this), 250)
-//   //   // );
-//   //   this._singleClickTimeout = setTimeout(function() {
-//   //     // if (oe && !oe._stopped) {
-//   //     map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
-//   //     // }
-//   //   }, 250);
-//   // },
-
-//   // _cancelSingleClick: function() {
-//   //   // This timeout is key to workaround an issue where double-click events
-//   //   // are fired in this order on some touch browsers: ['click', 'dblclick', 'click']
-//   //   // instead of ['click', 'click', 'dblclick']
-//   //   setTimeout(L.bind(this._clearSingleClickTimeout, this), 0);
-//   // },
-
-//   _onDoubleClick: function() {
-//     var map = this._map;
-//     var labels = map._labels;
-
-//     console.log('doubleclick');
-
-//     this._cancelSingleClick();
-
-//     if (labels.options.opacity === 1) {
-//       labels.options.opacity = 0;
-//       labels.setOpacity(0);
-//     } else {
-//       labels.options.opacity = 1;
-//       labels.setOpacity(1);
-//     }
-//   },
-// });
-
-// L.Map.addInitHook('addHandler', 'doubleClickLabels', L.Map.DoubleClickLabels);
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
   addHooks: function() {
     L.DomEvent.on(this._map, {
-      // pointerdown: this._fireIfSingle,
       click: this._fireIfSingle,
       dblclick: this._onDoubleClick,
     }, this);
   },
 
   removeHooks: function() {
-    // this._map.off({
-    //   click: this._fireIfSingle,
-    //   dblclick: this._onDoubleClick,
-    // }, this);
-    L.DomEvent.on(this._map, {
-      // tap: this._fireIfSingle,
-      // pointerdown: this._fireIfSingle,
+    L.DomEvent.off(this._map, {
       click: this._fireIfSingle,
       dblclick: this._onDoubleClick,
     }, this);
@@ -144,7 +32,6 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
       map.doubleClickZoom.disable();
     }
 
-    // signify to collection/instance classes to re-enable 'singleclick' listeners
     this._map.fire('singleclickon');
 
     this._enabled = true;
@@ -153,33 +40,35 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
   },
 
   disable: function() {
-    // var map = this._map;
-
     if (!this._enabled) { return this; }
 
     this._enabled = false;
     this.removeHooks();
-
-    // // enable 'doubleClickZoom' if 'doubleClickLabels' is disabled.
-    // if (!map.doubleClickZoom.enabled()) {
-    //   map.doubleClickZoom.enable();
-    // }
 
     return this;
   },
 
   _fireIfSingle: function(e) {
     var map = this._map;
-    var eo = e.originalEvent;
+    var oe = e.originalEvent;
 
     // prevents deselection in case of box selector
-    if (eo && eo.shiftKey) { return; }
+    if (oe && oe.shiftKey) { return; }
 
     map._clicked += 1;
     this._map._clickTimeout = setTimeout(function() {
       if (map._clicked === 1) {
         map._clicked = 0;
         map.fire('singleclick', {type: 'singleclick'});
+      } else {
+        // manually fire doubleclick event only for touch screens
+        if (L.Browser.touch) {
+          if (!L.Browser.pointer) {
+            map.fire('dblclick');
+          } else if (oe && oe.sourceCapabilities.firesTouchEvents) {
+            map.fire('dblclick');
+          }
+        }
       }
     }, 250);
   },
@@ -203,91 +92,4 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
   },
 });
 
-/**
- * a little repetitive, but here we overrwrite the L.Map.DoubleClickZoom
- * handler so that in case L.Map.DoubleClickLabels is disabled, this handler
- * will fire a `singleclick` event that our collection and overlay classes
- * both listen for. Bonus: now DoubleClickZoom doesn't deselect our images either.
- */
-L.Map.DoubleClickZoom.include({
-  addHooks: function() {
-    this._map.on({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
-
-  removeHooks: function() {
-    this._map.off({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
-
-  enable: function() {
-    if (this._enabled) { return this; }
-
-    // don't enable 'doubleClickZoom' unless 'doubleClickLabels' is disabled first
-    if (this._map.doubleClickLabels) {
-      if (this._map.doubleClickLabels.enabled()) {
-        return this;
-      }
-    }
-
-    this._map.fire('singleclickon');
-
-    this._enabled = true;
-    this.addHooks();
-    return this;
-  },
-
-  /**
-   * if L.Map.DoubleClickZoom is disabled as well, we fire one more custom event
-   * to signify to our collection and instance classes to stop listening for `singleclick`
-   * and start just listening for `click`.
-   */
-  disable: function() {
-    if (!this._enabled) { return this; }
-
-    this._map.fire('singleclickoff');
-
-    this._enabled = false;
-    this.removeHooks();
-    return this;
-  },
-
-  _fireIfSingle: function(e) {
-    var map = this._map;
-    var eo = e.originalEvent;
-
-    // prevents deselection in case of box selector
-    if (eo && eo.shiftKey) { return; }
-
-    map._clicked += 1;
-    setTimeout(function() {
-      if (map._clicked === 1) {
-        map._clicked = 0;
-        map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
-      }
-    }, 250);
-  },
-
-  _onDoubleClick: function(e) {
-    var map = this._map;
-
-    map._clicked = 0;
-
-    var oldZoom = map.getZoom();
-    var delta = map.options.zoomDelta;
-    var zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
-
-    if (map.options.doubleClickZoom === 'center') {
-      map.setZoom(zoom);
-    } else {
-      map.setZoomAround(e.containerPoint, zoom);
-    }
-  },
-});
-
 L.Map.addInitHook('addHandler', 'doubleClickLabels', L.Map.DoubleClickLabels);
-

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -6,22 +6,7 @@ L.Map.mergeOptions({
  * The `doubleClickLabels` handler replaces `doubleClickZoom` by default if `#addGoogleMutant`
  * is used unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
  */
-
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
-  addHooks: function() {
-    this._map.on({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
-
-  removeHooks: function() {
-    this._map.off({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
-
   enable: function() {
     var map = this._map;
 
@@ -62,16 +47,14 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
         map.fire('singleclick', {type: 'singleclick'});
       } else {
         // manually fire doubleclick event only for touch screens that don't natively fire it
-        if (L.Browser.touch) {
-          if (oe && oe.sourceCapabilities.firesTouchEvents) {
-            map.fire('dblclick');
-          }
+        if (L.Browser.touch && (oe && oe.sourceCapabilities.firesTouchEvents)) {
+          map.fire('dblclick');
         }
       }
     }, 250);
   },
 
-  _onDoubleClick: function() {
+  _onDoubleClick: function(e) {
     var map = this._map;
     var labels = map._labels;
 

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -1,40 +1,24 @@
+L.Map.mergeOptions({
+  doubleClickLabels: true,
+});
+
 /**
  * The 'doubleClickLabels' handler only runs instead of 'doubleClickZoom' when a googleMutant
  * layer is added to the map using 'map.addGoogleMutant()' without the option labels: false.
  */
 
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
-  addHooks: function() {
-    this._map.on({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
-
-  removeHooks: function() {
-    this._map.off({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
-
   enable: function() {
     var map = this._map;
 
     if (this._enabled) { return this; }
-
-    // dont enable 'doubleClickLabels' if the labels layer has not been added.
-    if (!map._labels) {
-      this._enabled = false;
-      return this;
-    }
 
     // disable 'doubleClickZoom' if 'doubleClickLabels' is enabled.
     if (map.doubleClickZoom.enabled()) {
       map.doubleClickZoom.disable();
     }
 
-    // signify to collection/instance classes to re-enable 'singleclick' listeners
+    // signify to collection/instance classes to listen for 'singleclick'
     this._map.fire('singleclickon');
 
     this._enabled = true;
@@ -43,40 +27,21 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
   },
 
   disable: function() {
-    var map = this._map;
-
     if (!this._enabled) { return this; }
+
+    this._map.fire('singleclickoff');
 
     this._enabled = false;
     this.removeHooks();
 
-    // enable 'doubleClickZoom' if 'doubleClickLabels' is disabled.
-    if (!map.doubleClickZoom.enabled()) {
-      map.doubleClickZoom.enable();
-    }
-
     return this;
-  },
-
-  _fireIfSingle: function(e) {
-    var map = this._map;
-    var eo = e.originalEvent;
-
-    // prevents deselection in case of box selector
-    if (eo && eo.shiftKey) { return; }
-
-    map._clicked += 1;
-    setTimeout(function() {
-      if (map._clicked === 1) {
-        map._clicked = 0;
-        map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
-      }
-    }, 250);
   },
 
   _onDoubleClick: function() {
     var map = this._map;
     var labels = map._labels;
+
+    this._cancelSingleClick();
 
     map._clicked = 0;
 
@@ -86,92 +51,6 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
     } else {
       labels.options.opacity = 1;
       labels.setOpacity(1);
-    }
-  },
-});
-
-/**
- * a little repetitive, but here we overrwrite the L.Map.DoubleClickZoom
- * handler so that in case L.Map.DoubleClickLabels is disabled, this handler
- * will fire a `singleclick` event that our collection and overlay classes
- * both listen for. Bonus: now DoubleClickZoom doesn't deselect our images either.
- */
-L.Map.DoubleClickZoom.include({
-  addHooks: function() {
-    this._map.on({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
-
-  removeHooks: function() {
-    this._map.off({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
-
-  enable: function() {
-    if (this._enabled) { return this; }
-
-    // don't enable 'doubleClickZoom' unless 'doubleClickLabels' is disabled first
-    if (this._map.doubleClickLabels) {
-      if (this._map.doubleClickLabels.enabled()) {
-        return this;
-      }
-    }
-
-    this._map.fire('singleclickon');
-
-    this._enabled = true;
-    this.addHooks();
-    return this;
-  },
-
-  /**
-   * if L.Map.DoubleClickZoom is disabled as well, we fire one more custom event
-   * to signify to our collection and instance classes to stop listening for `singleclick`
-   * and start just listening for `click`.
-   */
-  disable: function() {
-    if (!this._enabled) { return this; }
-
-    this._map.fire('singleclickoff');
-
-    this._enabled = false;
-    this.removeHooks();
-    return this;
-  },
-
-  _fireIfSingle: function(e) {
-    var map = this._map;
-    var eo = e.originalEvent;
-
-    // prevents deselection in case of box selector
-    if (eo && eo.shiftKey) { return; }
-
-    map._clicked += 1;
-    setTimeout(function() {
-      if (map._clicked === 1) {
-        map._clicked = 0;
-        map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
-      }
-    }, 250);
-  },
-
-  _onDoubleClick: function(e) {
-    var map = this._map;
-
-    map._clicked = 0;
-
-    var oldZoom = map.getZoom();
-    var delta = map.options.zoomDelta;
-    var zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
-
-    if (map.options.doubleClickZoom === 'center') {
-      map.setZoom(zoom);
-    } else {
-      map.setZoomAround(e.containerPoint, zoom);
     }
   },
 });

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -61,7 +61,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
         map._clicked = 0;
         map.fire('singleclick', {type: 'singleclick'});
       } else {
-        // manually fire doubleclick event only for touch screens
+        // manually fire doubleclick event only for touch screens that don't natively fire it
         if (L.Browser.touch) {
           if (oe && oe.sourceCapabilities.firesTouchEvents) {
             map.fire('dblclick');
@@ -79,6 +79,8 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
       map._clicked = 0;
       clearTimeout(map._clickTimeout);
     }, 0);
+
+    if (!labels) { return; }
 
     if (labels.options.opacity === 1) {
       labels.options.opacity = 0;

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -41,7 +41,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
     var map = this._map;
     var labels = map._labels;
 
-    this._cancelSingleClick();
+    // this._cancelSingleClick();
 
     map._clicked = 0;
 

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -3,8 +3,8 @@ L.Map.mergeOptions({
 });
 
 /**
- * The 'doubleClickLabels' handler replaces 'doubleClickZoom' by default when #addGoogleMutant is used
- * unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
+ * The 'doubleClickLabels' handler replaces 'doubleClickZoom' by default if #addGoogleMutant
+ * is used unless the options 'labels: false' or 'doubleClickZoom: false` were passed to it.
  */
 
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -54,7 +54,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
     }, 250);
   },
 
-  _onDoubleClick: function(e) {
+  _onDoubleClick: function() {
     var map = this._map;
     var labels = map._labels;
 

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -62,10 +62,8 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
         map.fire('singleclick', {type: 'singleclick'});
       } else {
         // manually fire doubleclick event only for touch screens
-        if (L.Browser.touch && L.Browser.chrome) {
-          if (!L.Browser.pointer) {
-            map.fire('dblclick');
-          } else if (oe && oe.sourceCapabilities.firesTouchEvents) {
+        if (L.Browser.touch) {
+          if (oe && oe.sourceCapabilities.firesTouchEvents) {
             map.fire('dblclick');
           }
         }

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -62,7 +62,7 @@ L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
         map.fire('singleclick', {type: 'singleclick'});
       } else {
         // manually fire doubleclick event only for touch screens
-        if (L.Browser.touch) {
+        if (L.Browser.touch && L.Browser.chrome) {
           if (!L.Browser.pointer) {
             map.fire('dblclick');
           } else if (oe && oe.sourceCapabilities.firesTouchEvents) {

--- a/src/mapmixins/DoubleClickLabels.js
+++ b/src/mapmixins/DoubleClickLabels.js
@@ -9,14 +9,14 @@ L.Map.mergeOptions({
 
 L.Map.DoubleClickLabels = L.Map.DoubleClickZoom.extend({
   addHooks: function() {
-    L.DomEvent.on(this._map, {
+    this._map.on({
       click: this._fireIfSingle,
       dblclick: this._onDoubleClick,
     }, this);
   },
 
   removeHooks: function() {
-    L.DomEvent.off(this._map, {
+    this._map.off({
       click: this._fireIfSingle,
       dblclick: this._onDoubleClick,
     }, this);

--- a/src/mapmixins/DoubleClickZoom.js
+++ b/src/mapmixins/DoubleClickZoom.js
@@ -1,7 +1,6 @@
 /**
- * we overrwrite the L.Map.DoubleClickZoom handler so that in case
- * L.Map.DoubleClickLabels is disabled, it will also will fire a `singleclick`
- * event so that images are not deselected on DoubleClickZoom either.
+ * L.Map.DoubleClickZoom from leaflet 1.5.1, overrwritten so that it fires a
+ * `singleclick` event to avoiding deselecting images on doubleclick.
  */
 L.Map.DoubleClickZoom.include({
   addHooks: function() {
@@ -35,14 +34,11 @@ L.Map.DoubleClickZoom.include({
     return this;
   },
 
-  /**
-   * if L.Map.DoubleClickZoom is disabled as well, we fire one more custom event
-   * to signify to our collection and instance classes to stop listening for `singleclick`
-   * and start just listening for `click`.
-   */
   disable: function() {
     if (!this._enabled) { return this; }
 
+    // if L.Map.DoubleClickLabels is disabled as well, collection/instance classes
+    // will stop listening for `singleclick` and start just listening for `click`.
     this._map.fire('singleclickoff');
 
     this._enabled = false;

--- a/src/mapmixins/DoubleClickZoom.js
+++ b/src/mapmixins/DoubleClickZoom.js
@@ -66,9 +66,9 @@ L.Map.DoubleClickZoom.include({
     this._singleClickTimeout = setTimeout(function() {
       if (map._clicked === 1) {
         map._clicked = 0;
-        if (eo && !eo._stopped) {
-          map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
-        }
+        // if (eo && !eo._stopped) {
+        map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
+        // }
       }
     }, 250);
   },
@@ -85,7 +85,7 @@ L.Map.DoubleClickZoom.include({
 
     map._clicked = 0;
 
-    this._cancelSingleClick();
+    // this._cancelSingleClick();
 
     var oldZoom = map.getZoom();
     var delta = map.options.zoomDelta;

--- a/src/mapmixins/DoubleClickZoom.js
+++ b/src/mapmixins/DoubleClickZoom.js
@@ -1,0 +1,104 @@
+/**
+ * we overrwrite the L.Map.DoubleClickZoom handler so that in case
+ * L.Map.DoubleClickLabels is disabled, it will also will fire a `singleclick`
+ * event so that images are not deselected on DoubleClickZoom either.
+ */
+L.Map.DoubleClickZoom.include({
+  addHooks: function() {
+    this._map.on({
+      click: this._fireIfSingle,
+      dblclick: this._onDoubleClick,
+    }, this);
+  },
+
+  removeHooks: function() {
+    this._map.off({
+      click: this._fireIfSingle,
+      dblclick: this._onDoubleClick,
+    }, this);
+  },
+
+  enable: function() {
+    if (this._enabled) { return this; }
+
+    // don't enable 'doubleClickZoom' unless 'doubleClickLabels' is disabled first
+    if (this._map.doubleClickLabels) {
+      if (this._map.doubleClickLabels.enabled()) {
+        return false;
+      }
+    }
+
+    this._map.fire('singleclickon');
+
+    this._enabled = true;
+    this.addHooks();
+    return this;
+  },
+
+  /**
+   * if L.Map.DoubleClickZoom is disabled as well, we fire one more custom event
+   * to signify to our collection and instance classes to stop listening for `singleclick`
+   * and start just listening for `click`.
+   */
+  disable: function() {
+    if (!this._enabled) { return this; }
+
+    this._map.fire('singleclickoff');
+
+    this._enabled = false;
+    this.removeHooks();
+    return this;
+  },
+
+  _clearSingleClickTimeout: function() {
+    if (this._singleClickTimeout) {
+      clearTimeout(this._singleClickTimeout);
+      this._singleClickTimeout = null;
+    }
+  },
+
+  _fireIfSingle: function(e) {
+    var map = this._map;
+    var eo = e.originalEvent;
+
+    // prevents deselection in case of box selector
+    if (eo && eo.shiftKey) { return; }
+
+    this._clearSingleClickTimeout();
+
+    map._clicked += 1;
+    this._singleClickTimeout = setTimeout(function() {
+      if (map._clicked === 1) {
+        map._clicked = 0;
+        if (eo && !eo._stopped) {
+          map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
+        }
+      }
+    }, 250);
+  },
+
+  _cancelSingleClick: function() {
+    // This timeout is key to workaround an issue where double-click events
+    // are fired in this order on some touch browsers: ['click', 'dblclick', 'click']
+    // instead of ['click', 'click', 'dblclick']
+    setTimeout(this._clearSingleClickTimeout.bind(this), 0);
+  },
+
+  _onDoubleClick: function(e) {
+    var map = this._map;
+
+    map._clicked = 0;
+
+    this._cancelSingleClick();
+
+    var oldZoom = map.getZoom();
+    var delta = map.options.zoomDelta;
+    var zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
+
+    if (map.options.doubleClickZoom === 'center') {
+      map.setZoom(zoom);
+    } else {
+      map.setZoomAround(e.containerPoint, zoom);
+    }
+  },
+});

--- a/src/mapmixins/DoubleClickZoom.js
+++ b/src/mapmixins/DoubleClickZoom.js
@@ -2,99 +2,112 @@
  * L.Map.DoubleClickZoom from leaflet 1.5.1, overrwritten so that it fires a
  * `singleclick` event to avoiding deselecting images on doubleclick.
  */
-L.Map.DoubleClickZoom.include({
-  addHooks: function() {
-    this._map.on({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
+// L.Map.DoubleClickZoom.include({
+//   addHooks: function() {
+//     // this._singleClickTimeout = null;
 
-  removeHooks: function() {
-    this._map.off({
-      click: this._fireIfSingle,
-      dblclick: this._onDoubleClick,
-    }, this);
-  },
+//     // L.DomEvent.on(this._map, {
+//     //   click: this._scheduleSingleClick,
+//     //   dblclick: this._onDoubleClick,
+//     // }, this);
+//     this._map.on({
+//       click: this._scheduleSingleClick,
+//       dblclick: this._onDoubleClick,
+//       dbltap: this._onDoubleClick,
+//     }, this);
+//   },
 
-  enable: function() {
-    if (this._enabled) { return this; }
+//   removeHooks: function() {
+//     this._map.singleClickTimeout = null;
 
-    // don't enable 'doubleClickZoom' unless 'doubleClickLabels' is disabled first
-    if (this._map.doubleClickLabels) {
-      if (this._map.doubleClickLabels.enabled()) {
-        return false;
-      }
-    }
+//     this._map.off({
+//       click: this._scheduleSingleClick,
+//       dblclick: this._onDoubleClick,
+//       dbltap: this._onDoubleClick,
+//     }, this);
+//   },
 
-    this._map.fire('singleclickon');
+//   enable: function() {
+//     var map = this._map;
 
-    this._enabled = true;
-    this.addHooks();
-    return this;
-  },
+//     if (this._enabled) { return this; }
 
-  disable: function() {
-    if (!this._enabled) { return this; }
+//     // don't enable 'doubleClickZoom' unless 'doubleClickLabels' is disabled first
+//     if (map.doubleClickLabels) {
+//       if (map.doubleClickLabels.enabled()) {
+//         return false;
+//       }
+//     }
 
-    // if L.Map.DoubleClickLabels is disabled as well, collection/instance classes
-    // will stop listening for `singleclick` and start just listening for `click`.
-    this._map.fire('singleclickoff');
+//     map.fire('singleclickon');
 
-    this._enabled = false;
-    this.removeHooks();
-    return this;
-  },
+//     this._enabled = true;
+//     this.addHooks();
+//     return this;
+//   },
 
-  _clearSingleClickTimeout: function() {
-    if (this._singleClickTimeout) {
-      clearTimeout(this._singleClickTimeout);
-      this._singleClickTimeout = null;
-    }
-  },
+//   disable: function() {
+//     if (!this._enabled) { return this; }
 
-  _fireIfSingle: function(e) {
-    var map = this._map;
-    var eo = e.originalEvent;
+//     // if L.Map.DoubleClickLabels is disabled as well, collection/instance classes
+//     // will stop listening for `singleclick` and start just listening for `click`.
+//     this._map.fire('singleclickoff');
 
-    // prevents deselection in case of box selector
-    if (eo && eo.shiftKey) { return; }
+//     this._enabled = false;
+//     this.removeHooks();
+//     return this;
+//   },
 
-    this._clearSingleClickTimeout();
+//   _clearSingleClickTimeout: function() {
+//     if (this._map._singleClickTimeout !== null) {
+//       console.log('clearclicktimeout');
+//       clearTimeout(this._map._singleClickTimeout);
+//       this._map._singleClickTimeout = null;
+//     }
+//   },
 
-    map._clicked += 1;
-    this._singleClickTimeout = setTimeout(function() {
-      if (map._clicked === 1) {
-        map._clicked = 0;
-        // if (eo && !eo._stopped) {
-        map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
-        // }
-      }
-    }, 250);
-  },
+//   _scheduleSingleClick: function(e) {
+//     var oe = e.originalEvent;
+//     var map = this._map;
 
-  _cancelSingleClick: function() {
-    // This timeout is key to workaround an issue where double-click events
-    // are fired in this order on some touch browsers: ['click', 'dblclick', 'click']
-    // instead of ['click', 'click', 'dblclick']
-    setTimeout(this._clearSingleClickTimeout.bind(this), 0);
-  },
+//     // prevents deselection in case of box selector
+//     if (oe && oe.shiftKey) { return; }
 
-  _onDoubleClick: function(e) {
-    var map = this._map;
+//     console.log('singleclick');
+//     this._clearSingleClickTimeout();
 
-    map._clicked = 0;
+//     // this._singleClickTimeout = (
+//     // setTimeout(L.bind(this._fireSingleClick, e, this), 250)
+//     // );
+//     this._map._singleClickTimeout = setTimeout(function() {
+//       // if (oe && !oe._stopped) {
+//       map.fire('singleclick', L.extend(e, {type: 'singleclick'}));
+//       // }
+//     }, 250);
+//   },
 
-    // this._cancelSingleClick();
+//   _cancelSingleClick: function() {
+//     // This timeout is key to workaround an issue where double-click events
+//     // are fired in this order on some touch browsers: ['click', 'dblclick', 'click']
+//     // instead of ['click', 'click', 'dblclick']
+//     setTimeout(L.bind(this._clearSingleClickTimeout, this), 0);
+//   },
 
-    var oldZoom = map.getZoom();
-    var delta = map.options.zoomDelta;
-    var zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
+//   _onDoubleClick: function(e) {
+//     var map = this._map;
 
-    if (map.options.doubleClickZoom === 'center') {
-      map.setZoom(zoom);
-    } else {
-      map.setZoomAround(e.containerPoint, zoom);
-    }
-  },
-});
+//     console.log('doubleclick');
+
+//     this._cancelSingleClick();
+
+//     var oldZoom = map.getZoom();
+//     var delta = map.options.zoomDelta;
+//     var zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
+
+//     if (map.options.doubleClickZoom === 'center') {
+//       map.setZoom(zoom);
+//     } else {
+//       map.setZoomAround(e.containerPoint, zoom);
+//     }
+//   },
+// });

--- a/src/mapmixins/DoubleClickZoom.js
+++ b/src/mapmixins/DoubleClickZoom.js
@@ -63,12 +63,10 @@ L.Map.DoubleClickZoom.include({
       } else {
         // manually fire doubleclick event only for touch screens
         if (L.Browser.touch) {
-          if (!L.Browser.pointer) {
+          if (oe && oe.sourceCapabilities.firesTouchEvents) {
             // in `DoubleClickLabels.js`, we just do map.fire('dblclick') bc `_onDoublClick` doesn't use the
             // passed "e" (for now). To generate a 'real' DOM event that will have all of its corresponding core
             // properties (originalEvent, latlng, etc.), use Leaflet's `#map._fireDOMEvent` (Leaflet 1.5.1 source)
-            map._fireDOMEvent(oe, 'dblclick', [map]);
-          } else if (oe && oe.sourceCapabilities.firesTouchEvents) {
             map._fireDOMEvent(oe, 'dblclick', [map]);
           }
         }

--- a/src/mapmixins/DoubleClickZoom.js
+++ b/src/mapmixins/DoubleClickZoom.js
@@ -1,6 +1,6 @@
 /**
  * `L.Map.DoubleClickZoom` from leaflet 1.5.1, overrwritten so that it
- * 1)fires a `singleclick` event to avoid deselecting images on `dblclick`.
+ * 1) Fires a `singleclick` event to avoid deselecting images on `dblclick`.
  * 2) Maintains a mutually exclusive relationship with the map's `DoubleClickLabels` handler
  */
 
@@ -61,7 +61,7 @@ L.Map.DoubleClickZoom.include({
         map._clicked = 0;
         map.fire('singleclick', {type: 'singleclick'});
       } else {
-        // manually fire doubleclick event only for touch screens
+        // manually fire doubleclick event only for touch screens that don't natively fire it
         if (L.Browser.touch) {
           if (oe && oe.sourceCapabilities.firesTouchEvents) {
             // in `DoubleClickLabels.js`, we just do map.fire('dblclick') bc `_onDoublClick` doesn't use the

--- a/src/mapmixins/DoubleClickZoom.js
+++ b/src/mapmixins/DoubleClickZoom.js
@@ -3,7 +3,6 @@
  * 1) Fires a `singleclick` event to avoid deselecting images on `dblclick`.
  * 2) Maintains a mutually exclusive relationship with the map's `DoubleClickLabels` handler
  */
-
 L.Map.DoubleClickZoom.include({
   addHooks: function() {
     this._map.on({
@@ -62,13 +61,11 @@ L.Map.DoubleClickZoom.include({
         map.fire('singleclick', {type: 'singleclick'});
       } else {
         // manually fire doubleclick event only for touch screens that don't natively fire it
-        if (L.Browser.touch) {
-          if (oe && oe.sourceCapabilities.firesTouchEvents) {
-            // in `DoubleClickLabels.js`, we just do map.fire('dblclick') bc `_onDoublClick` doesn't use the
-            // passed "e" (for now). To generate a 'real' DOM event that will have all of its corresponding core
-            // properties (originalEvent, latlng, etc.), use Leaflet's `#map._fireDOMEvent` (Leaflet 1.5.1 source)
-            map._fireDOMEvent(oe, 'dblclick', [map]);
-          }
+        if (L.Browser.touch && (oe && oe.sourceCapabilities.firesTouchEvents)) {
+          // in `DoubleClickLabels.js`, we just do map.fire('dblclick') bc `_onDoublClick` doesn't use the
+          // passed "e" (for now). To generate a 'real' DOM event that will have all of its corresponding core
+          // properties (originalEvent, latlng, etc.), use Leaflet's `#map._fireDOMEvent` (Leaflet 1.5.1 source)
+          map._fireDOMEvent(oe, 'dblclick', [map]);
         }
       }
     }, 250);

--- a/src/mapmixins/MapMixins.js
+++ b/src/mapmixins/MapMixins.js
@@ -34,8 +34,8 @@ L.Map.include({
     // disables and removes from map - shouldn't have this handler at all if there
     // are no labels to toggle
     else {
-      this.doubleClickLabels.disable();
-      this.doubleClickZoom.enable();
+      // this.doubleClickLabels.disable();
+      // this.doubleClickZoom.enable();
       this.doubleClickLabels = undefined;
     }
 
@@ -60,11 +60,16 @@ L.Map.include({
     }).addTo(this);
 
     // disables but keeps on map (can re-enable)
-    if (!this.mutantOptions.doubleClickLabels) {
-      this.doubleClickLabels.disable();
-      this.doubleClickZoom.enable();
+    if (this.mutantOptions.doubleClickLabels) {
+      this.doubleClickLabels.enable();
+      // this.doubleClickZoom.enable();
     }
 
     return this;
   },
+});
+
+L.Map.addInitHook(function() {
+  this.doubleClickLabels.disable();
+  this.doubleClickZoom.enable();
 });

--- a/src/mapmixins/MapMixins.js
+++ b/src/mapmixins/MapMixins.js
@@ -1,35 +1,55 @@
+/* eslint-disable max-len */
 L.Map.include({
 
   _clicked: 0,
 
   addGoogleMutant: function(opts) {
-    opts = this._mutantOptions = L.Util.extend({
-      labels: true,
-      labelOpacity: 0,
+    var url = 'http://mt0.google.com/vt/lyrs=s&x={x}&y={y}&z={z}';
+
+    opts = this.mutantOptions = L.extend({
       mutantOpacity: 0.8,
       maxZoom: 18,
       minZoom: 0,
+      labels: true,
+      labelOpacity: 1,
+      doubleClickLabels: true,
     }, opts);
 
     if (opts.maxZoom > 21) { opts.maxZoom = 18; }
 
-    this._googleMutant = L.tileLayer('http://mt0.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+    if (!opts.labels) {
+      this.mutantOptions = L.extend(this.mutantOptions, {
+        labelOpacity: opts.labels ? 1 : undefined,
+        doubleClickLabels: opts.labels,
+      });
+    }
+
+    this._googleMutant = L.tileLayer(url, {
       maxZoom: opts.maxZoom,
       minZoom: opts.minZoom,
       opacity: opts.mutantOpacity,
     }).addTo(this);
 
     if (opts.labels) { this._addLabels(opts); }
+    // disables and removes from map - shouldn't have this handler at all if there
+    // are no labels to toggle
+    else {
+      this.doubleClickLabels.disable();
+      this.doubleClickZoom.enable();
+      this.doubleClickLabels = undefined;
+    }
 
     return this;
   },
 
   _addLabels: function(opts) {
+    var url = 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner-labels/{z}/{x}/{y}{r}.{ext}';
+
     if (opts.labelOpacity !== 0 && opts.labelOpacity !== 1) {
-      opts.labelOpacity = 0;
+      opts.labelOpacity = 1;
     }
 
-    this._labels = L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner-labels/{z}/{x}/{y}{r}.{ext}', {
+    this._labels = L.tileLayer(url, {
       attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       subdomains: 'abcd',
       interactive: false,
@@ -39,7 +59,11 @@ L.Map.include({
       ext: 'png',
     }).addTo(this);
 
-    this.doubleClickLabels.enable();
+    // disables but keeps on map (can re-enable)
+    if (!this.mutantOptions.doubleClickLabels) {
+      this.doubleClickLabels.disable();
+      this.doubleClickZoom.enable();
+    }
 
     return this;
   },

--- a/src/mapmixins/MapMixins.js
+++ b/src/mapmixins/MapMixins.js
@@ -20,7 +20,7 @@ L.Map.include({
     if (!opts.labels) {
       this.mutantOptions = L.extend(this.mutantOptions, {
         labelOpacity: opts.labels ? 1 : undefined,
-        doubleClickLabels: opts.labels,
+        doubleClickLabels: opts.labels ? true : undefined,
       });
     }
 

--- a/src/mapmixins/MapMixins.js
+++ b/src/mapmixins/MapMixins.js
@@ -1,6 +1,8 @@
 /* eslint-disable max-len */
 L.Map.include({
 
+  _singleClickTimeout: null,
+
   _clicked: 0,
 
   addGoogleMutant: function(opts) {

--- a/src/mapmixins/MapMixins.js
+++ b/src/mapmixins/MapMixins.js
@@ -1,8 +1,6 @@
 /* eslint-disable max-len */
 L.Map.include({
 
-  _singleClickTimeout: null,
-
   _clicked: 0,
 
   addGoogleMutant: function(opts) {
@@ -68,37 +66,5 @@ L.Map.include({
     }
 
     return this;
-  },
-
-  _fireDOMEventNoPreclick: function(e, type, targets) {
-    if (e._stopped) { return; }
-
-    // Find the layer the event is propagating from and its parents.
-    targets = (targets || []).concat(this._findEventTargets(e, type));
-
-    if (!targets.length) { return; }
-
-    var target = targets[0];
-    if (type === 'contextmenu' && target.listens(type, true)) {
-      L.DomEvent.preventDefault(e);
-    }
-
-    var data = {
-      originalEvent: e,
-    };
-
-    if (e.type !== 'keypress' && e.type !== 'keydown' && e.type !== 'keyup') {
-      var isMarker = target.getLatLng && (!target._radius || target._radius <= 10);
-      data.containerPoint = isMarker ?
-        this.latLngToContainerPoint(target.getLatLng()) : this.mouseEventToContainerPoint(e);
-      data.layerPoint = this.containerPointToLayerPoint(data.containerPoint);
-      data.latlng = isMarker ? target.getLatLng() : this.layerPointToLatLng(data.layerPoint);
-    }
-
-    for (var i = 0; i < targets.length; i++) {
-      targets[i].fire(type, data, true);
-      if (data.originalEvent._stopped ||
-        (targets[i].options.bubblingMouseEvents === false && L.Util.indexOf(this._mouseEvents, type) !== -1)) { return; }
-    }
   },
 });

--- a/src/mapmixins/MapMixins.js
+++ b/src/mapmixins/MapMixins.js
@@ -69,4 +69,36 @@ L.Map.include({
 
     return this;
   },
+
+  _fireDOMEventNoPreclick: function(e, type, targets) {
+    if (e._stopped) { return; }
+
+    // Find the layer the event is propagating from and its parents.
+    targets = (targets || []).concat(this._findEventTargets(e, type));
+
+    if (!targets.length) { return; }
+
+    var target = targets[0];
+    if (type === 'contextmenu' && target.listens(type, true)) {
+      L.DomEvent.preventDefault(e);
+    }
+
+    var data = {
+      originalEvent: e,
+    };
+
+    if (e.type !== 'keypress' && e.type !== 'keydown' && e.type !== 'keyup') {
+      var isMarker = target.getLatLng && (!target._radius || target._radius <= 10);
+      data.containerPoint = isMarker ?
+        this.latLngToContainerPoint(target.getLatLng()) : this.mouseEventToContainerPoint(e);
+      data.layerPoint = this.containerPointToLayerPoint(data.containerPoint);
+      data.latlng = isMarker ? target.getLatLng() : this.layerPointToLatLng(data.layerPoint);
+    }
+
+    for (var i = 0; i < targets.length; i++) {
+      targets[i].fire(type, data, true);
+      if (data.originalEvent._stopped ||
+        (targets[i].options.bubblingMouseEvents === false && L.Util.indexOf(this._mouseEvents, type) !== -1)) { return; }
+    }
+  },
 });

--- a/src/mapmixins/MapMixins.js
+++ b/src/mapmixins/MapMixins.js
@@ -31,11 +31,8 @@ L.Map.include({
     }).addTo(this);
 
     if (opts.labels) { this._addLabels(opts); }
-    // disables and removes from map - shouldn't have this handler at all if there
-    // are no labels to toggle
+    // shouldn't have this handler at all if there are no labels to toggle
     else {
-      // this.doubleClickLabels.disable();
-      // this.doubleClickZoom.enable();
       this.doubleClickLabels = undefined;
     }
 
@@ -59,16 +56,15 @@ L.Map.include({
       ext: 'png',
     }).addTo(this);
 
-    // disables but keeps on map (can re-enable)
     if (this.mutantOptions.doubleClickLabels) {
       this.doubleClickLabels.enable();
-      // this.doubleClickZoom.enable();
     }
 
     return this;
   },
 });
-
+// start off with doubleClickZoom enabled, doubleClickLabels can later be enabled instead
+// during initialization
 L.Map.addInitHook(function() {
   this.doubleClickLabels.disable();
   this.doubleClickZoom.enable();

--- a/src/util/DomUtil.js
+++ b/src/util/DomUtil.js
@@ -52,4 +52,11 @@ L.DomUtil = L.extend(L.DomUtil, {
     return window.confirm('Are you sure? ' + n +
     ' ' + humanized + ' will be permanently deleted from the map.');
   },
+
+  browserFiresNativeDblClick: function(e) {
+    // See https://github.com/w3c/pointerevents/issues/171
+    // Note however, that Chrome stopped firing native dblclick for
+    // touch since that issue was written.
+    return (L.Browser.ie || e.pointerType === 'mouse');
+  },
 });

--- a/src/util/DomUtil.js
+++ b/src/util/DomUtil.js
@@ -52,11 +52,4 @@ L.DomUtil = L.extend(L.DomUtil, {
     return window.confirm('Are you sure? ' + n +
     ' ' + humanized + ' will be permanently deleted from the map.');
   },
-
-  browserFiresNativeDblClick: function(e) {
-    // See https://github.com/w3c/pointerevents/issues/171
-    // Note however, that Chrome stopped firing native dblclick for
-    // touch since that issue was written.
-    return (L.Browser.ie || e.pointerType === 'mouse');
-  },
 });

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -35,7 +35,6 @@ module.exports = function(config) {
       'src/DistortableImageOverlay.js',
       'src/DistortableCollection.js',
       'src/edit/getEXIFdata.js',
-      'src/mapmixins/MapMixins.js',
       'src/mapmixins/DoubleClickZoom.js',
       'src/mapmixins/*.js',
       'src/edit/handles/EditHandle.js',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -35,6 +35,8 @@ module.exports = function(config) {
       'src/DistortableImageOverlay.js',
       'src/DistortableCollection.js',
       'src/edit/getEXIFdata.js',
+      'src/mapmixins/MapMixins.js',
+      'src/mapmixins/DoubleClickZoom.js',
       'src/mapmixins/*.js',
       'src/edit/handles/EditHandle.js',
       'src/edit/handles/*.js',

--- a/test/src/DistortableImageOverlaySpec.js
+++ b/test/src/DistortableImageOverlaySpec.js
@@ -162,10 +162,8 @@ describe('L.DistortableImageOverlay', function() {
       expect(Math.round(scaledC1.lng)).to.equal(Math.round(c2.lng));
     });
 
-    it('Maintain image proportions when scaling', function() {
+    it('Maintains image proportions when scaling', function() {
       var center = overlay.getCenter();
-
-      overlay.scaleBy(0.5);
 
       expect(Math.round(overlay.getCenter().lat)).to.equal(Math.round(center.lat));
       expect(Math.round(overlay.getCenter().lng)).to.equal(Math.round(center.lng));

--- a/test/src/edit/DistortableCollectionEditSpec.js
+++ b/test/src/edit/DistortableCollectionEditSpec.js
@@ -81,11 +81,13 @@ describe('L.DistortableCollection.Edit', function() {
 
       setTimeout(function() {
         edit._handles['distort'].eachLayer(function(handle) {
-          distortHandleState.push(handle._icon.style.opacity);
+          var icon = handle.getElement();
+          distortHandleState.push(L.DomUtil.getStyle(icon, 'opacity'));
         });
 
         edit2._handles['lock'].eachLayer(function(handle) {
-          lockHandleState.push(handle._icon.style.opacity);
+          var icon = handle.getElement();
+          lockHandleState.push(L.DomUtil.getStyle(icon, 'opacity'));
         });
 
         expect(distortHandleState).to.deep.equal(['0', '0', '0', '0']);

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -136,17 +136,17 @@ describe('L.DistortableImage.Edit', function() {
       expect(newIdx).to.equal((idx + 1) % modes.length)
     });
 
-    // it('Will only update if the image is selected, or nextMode was triggerd by dblclick', function() {
-    //   var edit = overlay.editing;
+    it('Will only update if the image is selected, or nextMode was triggerd by dblclick', function() {
+      var edit = overlay.editing;
 
-    //   overlay.deselect();
-    //   expect(edit.nextMode()).to.be.false
+      overlay.deselect();
+      expect(edit.nextMode()).to.be.false
 
-    //   chai.simulateEvent(overlay.getElement(), chai.mouseEvents.Dblclick);
-    //   setTimeout(function () {
-    //     expect(edit.nextMode()).to.be.ok
-    //   }, 3000);
-    // });
+      chai.simulateEvent(overlay.getElement(), chai.mouseEvents.Dblclick);
+      setTimeout(function () {
+        expect(edit.nextMode()).to.be.ok
+      }, 3000);
+    });
 
     it('It prevents dblclick events from propagating to the map', function() {
       var overlaySpy = sinon.spy();

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -136,17 +136,17 @@ describe('L.DistortableImage.Edit', function() {
       expect(newIdx).to.equal((idx + 1) % modes.length)
     });
 
-    it('Will only update if the image is selected, or nextMode was triggerd by dblclick', function() {
-      var edit = overlay.editing;
+    // it('Will only update if the image is selected, or nextMode was triggerd by dblclick', function() {
+    //   var edit = overlay.editing;
 
-      overlay.deselect();
-      expect(edit.nextMode()).to.be.false
+    //   overlay.deselect();
+    //   expect(edit.nextMode()).to.be.false
 
-      chai.simulateEvent(overlay.getElement(), chai.mouseEvents.Dblclick);
-      setTimeout(function () {
-        expect(edit.nextMode()).to.be.ok
-      }, 3000);
-    });
+    //   chai.simulateEvent(overlay.getElement(), chai.mouseEvents.Dblclick);
+    //   setTimeout(function () {
+    //     expect(edit.nextMode()).to.be.ok
+    //   }, 3000);
+    // });
 
     it('It prevents dblclick events from propagating to the map', function() {
       var overlaySpy = sinon.spy();

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -73,7 +73,8 @@ describe('L.DistortableImage.Edit', function() {
 
       var handleState = [];
       edit._handles['distort'].eachLayer(function(handle) {
-        handleState.push(handle._icon.style.opacity);
+        var icon = handle.getElement();
+        handleState.push(L.DomUtil.getStyle(icon, 'opacity'));
       });
 
       expect(handleState).to.deep.equal(['0', '0', '0', '0']);
@@ -90,11 +91,11 @@ describe('L.DistortableImage.Edit', function() {
 
       var lockHandleState = [];
       edit._handles['lock'].eachLayer(function(handle) {
-        lockHandleState.push(handle._icon.style.opacity);
+        var icon = handle.getElement();
+        lockHandleState.push(L.DomUtil.getStyle(icon, 'opacity'));
       });
 
-      // opacity for lockHandles is unset because we never altered it to hide it as part of deselection
-      expect(lockHandleState).to.deep.equal(['', '', '', '']);
+      expect(lockHandleState).to.deep.equal(['1', '1', '1', '1']);
     });
 
     it('Should remove an image\'s individual toolbar instance regardless of lock handles', function() {


### PR DESCRIPTION
Fixes #439  (<=== Add issue number here)
Fixes #350 

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updates
* [ ] @mention the original creator of the issue in a comment below for help or for a review

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!


=================
changes:
- separated out `DoubleClickZoom` into its own file from `DoubleClickLabels`
- bump to `0.8.4`
- remove (/replace) some deprecated source code from `L.DistortableImageOverlay`
   - removes the bug where the image flashes in the corner of the screen for a second before moving to its spot in the center by not adding the image element to the map until it is actually loaded.
- make `doubleTap` events work in Chrome -- see pending part below. Documentation that it doesnt work: https://github.com/Leaflet/Leaflet/issues/6777, https://github.com/Leaflet/Leaflet/pull/5881
   - Tested on Mobile: Chrome, Firefox, Safari, Opera, Samsung Internet, Edge
   - Desktop Chrome, IE 9 - IE 11, Firefox, Safari, Opera, Edge
- check scenario where user skips call to `addGoogleMutant` & confirm correct state of `dblclick` handlers.
- documented `singleclick` event in wiki: https://github.com/publiclab/Leaflet.DistortableImage/wiki/singleclick-event

