### PR TITLE
Add a `#replaceTool` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,10 @@ Same as `L.DistortableImage.Edit` but for the collection (`L.DistortableCollecti
 <ul><li>Adds the passed tool to the end of the control toolbar in runtime. Returns false if the tool is not available or is already present.</li></ul>
 </details>
 
+<details><summary><code><b>replaceTool(<i>old</i> &#60;EditAction>), <i>next</i> &#60;EditAction>)</b></code></summary>
+<ul><li>Replaces the first parameter with the second parameter. Returns false if the first parameter is not found. Also returns false if the second parameter is not available or is already present.</li></ul>
+</details>
+
 <details><summary><code><b>hasTool(<i>action</i> &#60;EditAction>)</b>: Boolean</code></summary>
 <ul><li>Returns true if the tool is present in the currently rendered control toolbar.</li></ul>
 </details>

--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ Same as `L.DistortableImage.Edit` but for the collection (`L.DistortableCollecti
 </details>
 
 <details><summary><code><b>replaceTool(<i>old</i> &#60;EditAction>), <i>next</i> &#60;EditAction>)</b></code></summary>
-<ul><li>Replaces the first parameter with the second parameter. Returns false if the first parameter is not found. Also returns false if the second parameter is not available or is already present.</li></ul>
+<ul><li>Replaces the first parameter with the second parameter.</li></ul>
 </details>
 
 <details><summary><code><b>hasTool(<i>action</i> &#60;EditAction>)</b>: Boolean</code></summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-distortableimage",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Leaflet plugin enabling image overlays to be distorted, stretched, and warped (built for Public Lab's MapKnitter: http://publiclab.org).",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -175,10 +175,10 @@ L.DistortableImage.Edit = L.Handler.extend({
 
   replaceTool: function(old, next) {
     if (next.baseClass !== 'leaflet-toolbar-icon' || this.hasTool(next)) {
-      return false;
+      return;
     }
 
-    return this.editActions.some(function(item, idx) {
+    this.editActions.some(function(item, idx) {
       if (this.editActions[idx] === old) {
         this._removeToolbar();
         this.editActions[idx] = next;

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -173,6 +173,23 @@ L.DistortableImage.Edit = L.Handler.extend({
     }
   },
 
+  replaceTool: function(old, next) {
+    if (value.baseClass === 'leaflet-toolbar-icon' && !this.hasTool(value)) {
+      return false;
+    }
+
+    this.editActions.some(function(item, idx) {
+      if (this.editActions[idx] === value) {
+        this._removeToolbar();
+        this.editActions[idx] = next;
+        this._addToolbar();
+        return true;
+      } else {
+        return false;
+      }
+    }, this);
+  },
+
   addTool: function(value) {
     if (value.baseClass === 'leaflet-toolbar-icon' && !this.hasTool(value)) {
       this._removeToolbar();

--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -174,12 +174,12 @@ L.DistortableImage.Edit = L.Handler.extend({
   },
 
   replaceTool: function(old, next) {
-    if (value.baseClass === 'leaflet-toolbar-icon' && !this.hasTool(value)) {
+    if (next.baseClass !== 'leaflet-toolbar-icon' || this.hasTool(next)) {
       return false;
     }
 
-    this.editActions.some(function(item, idx) {
-      if (this.editActions[idx] === value) {
+    return this.editActions.some(function(item, idx) {
+      if (this.editActions[idx] === old) {
         this._removeToolbar();
         this.editActions[idx] = next;
         this._addToolbar();

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -63,6 +63,49 @@ describe('L.DistortableImage.Edit', function() {
     });
   });
 
+  describe('#replaceTool', function() {
+    it('It should replace an existing action', function() {
+      var old = overlay.editing.editActions[0];
+      var next = overlay.editing.editActions[1];
+      var edit = overlay.editing;
+
+      edit.removeTool(next);
+
+      var res = edit.replaceTool(old, next);
+      expect(res).to.be.true;
+
+      expect(edit.hasTool(old)).to.be.false;
+      expect(edit.hasTool(next)).to.be.true;
+      expect(edit.editActions[0]).to.equal(next);
+    });
+
+    it('It should do nothing if the first parameter does not exist', function() {
+      var old = overlay.editing.editActions[0];
+      var next = overlay.editing.editActions[1];
+      var edit = overlay.editing;
+
+      edit.removeTool(old);
+
+      var res = edit.replaceTool(old, next);
+      expect(res).to.be.false;
+
+      expect(edit.hasTool(old)).to.be.false;
+      expect(edit.hasTool(next)).to.be.true;
+    });
+
+    it('It should do nothing if the second parameter already exists', function() {
+      var old = overlay.editing.editActions[0];
+      var next = overlay.editing.editActions[1];
+      var edit = overlay.editing;
+
+      var res = edit.replaceTool(old, next);
+      expect(res).to.be.false;
+
+      expect(edit.hasTool(old)).to.be.true;
+      expect(edit.hasTool(next)).to.be.true;
+    });
+  });
+
   describe('#_deselect', function() {
     it('It should hide an unlocked image\'s handles by updating their opacity', function() {
       var edit = overlay.editing;
@@ -120,7 +163,7 @@ describe('L.DistortableImage.Edit', function() {
     });
   });
 
-  describe('#nextMode', function () {
+  describe('#nextMode', function() {
     beforeEach(function() {
       overlay.editing.enable();
       overlay.select();
@@ -130,22 +173,22 @@ describe('L.DistortableImage.Edit', function() {
       var edit = overlay.editing;
       var modes = edit.getModes();
 
-      edit._mode = 'distort'
+      edit._mode = 'distort';
       var idx = modes.indexOf('distort');
 
-      var newIdx = modes.indexOf(edit.nextMode()._mode)
-      expect(newIdx).to.equal((idx + 1) % modes.length)
+      var newIdx = modes.indexOf(edit.nextMode()._mode);
+      expect(newIdx).to.equal((idx + 1) % modes.length);
     });
 
     it('Will only update if the image is selected, or nextMode was triggerd by dblclick', function() {
       var edit = overlay.editing;
 
       overlay.deselect();
-      expect(edit.nextMode()).to.be.false
+      expect(edit.nextMode()).to.be.false;
 
       chai.simulateEvent(overlay.getElement(), chai.mouseEvents.Dblclick);
-      setTimeout(function () {
-        expect(edit.nextMode()).to.be.ok
+      setTimeout(function() {
+        expect(edit.nextMode()).to.be.ok;
       }, 3000);
     });
 
@@ -155,10 +198,10 @@ describe('L.DistortableImage.Edit', function() {
 
       overlay.on('dblclick', overlaySpy);
       map.on('dblclick', mapSpy);
-      
+
       overlay.fire('dblclick');
 
-      setTimeout(function () {
+      setTimeout(function() {
         expect(overlay.editing.nextMode).to.have.been.called;
         expect(L.DomEvent.stop).to.have.been.called;
 
@@ -167,7 +210,7 @@ describe('L.DistortableImage.Edit', function() {
       }, 3000);
     });
 
-    it('Should call #setMode', function () {
+    it('Should call #setMode', function() {
       var overlaySpy = sinon.spy();
       overlay.on('dblclick', overlaySpy);
 
@@ -177,35 +220,35 @@ describe('L.DistortableImage.Edit', function() {
 
     it('Will still update the mode of an initialized image with suppressToolbar: true', function() {
       ov2.select();
-      expect(ov2.editing.toolbar).to.be.undefined
-      expect(ov2.editing.nextMode()).to.be.ok
-    })
+      expect(ov2.editing.toolbar).to.be.undefined;
+      expect(ov2.editing.nextMode()).to.be.ok;
+    });
   });
 
   describe('#setMode', function() {
     it('Will return false if the passed value is not in the image\'s modes array', function() {
       var edit = overlay.editing;
       overlay.select();
-      expect(edit.setMode('lock')).to.be.ok
-      expect(edit.setMode('blah')).to.be.false
+      expect(edit.setMode('lock')).to.be.ok;
+      expect(edit.setMode('blah')).to.be.false;
     });
 
     it('Will return false if the image is not selected', function() {
       var edit = overlay.editing;
-      expect(edit.setMode('lock')).to.be.false
+      expect(edit.setMode('lock')).to.be.false;
     });
 
     it('Will return false if the passed mode is already the images mode', function() {
       var edit = overlay.editing;
       overlay.select();
-      expect(edit.setMode('lock')).to.be.ok
-      expect(edit.setMode('lock')).to.be.false
+      expect(edit.setMode('lock')).to.be.ok;
+      expect(edit.setMode('lock')).to.be.false;
     });
 
-    it('Will still update the mode of an initialized image with suppressToolbar: true', function () {
+    it('Will still update the mode of an initialized image with suppressToolbar: true', function() {
       ov2.select();
-      expect(ov2.editing.toolbar).to.be.undefined
-      expect(ov2.editing.setMode('lock')).to.be.ok
-    })
+      expect(ov2.editing.toolbar).to.be.undefined;
+      expect(ov2.editing.setMode('lock')).to.be.ok;
+    });
   });
 });

--- a/test/src/edit/DistortableImageEditSpec.js
+++ b/test/src/edit/DistortableImageEditSpec.js
@@ -71,8 +71,7 @@ describe('L.DistortableImage.Edit', function() {
 
       edit.removeTool(next);
 
-      var res = edit.replaceTool(old, next);
-      expect(res).to.be.true;
+      edit.replaceTool(old, next);
 
       expect(edit.hasTool(old)).to.be.false;
       expect(edit.hasTool(next)).to.be.true;
@@ -86,8 +85,7 @@ describe('L.DistortableImage.Edit', function() {
 
       edit.removeTool(old);
 
-      var res = edit.replaceTool(old, next);
-      expect(res).to.be.false;
+      edit.replaceTool(old, next);
 
       expect(edit.hasTool(old)).to.be.false;
       expect(edit.hasTool(next)).to.be.true;
@@ -98,8 +96,7 @@ describe('L.DistortableImage.Edit', function() {
       var next = overlay.editing.editActions[1];
       var edit = overlay.editing;
 
-      var res = edit.replaceTool(old, next);
-      expect(res).to.be.false;
+      edit.replaceTool(old, next);
 
       expect(edit.hasTool(old)).to.be.true;
       expect(edit.hasTool(next)).to.be.true;


### PR DESCRIPTION
Resolves https://github.com/publiclab/Leaflet.DistortableImage/issues/367

@sashadev-sky @rexagod Could you please take a look at this? 

This should cover all four features described in *Part 1*. There were some linting errors that were already present, so I had to commit with `--no-verify` to bypass the pre-commit hook. Perhaps this would be worth fixing in a separate PR? 

I'm not too sure if the tests I added are entirely comprehensive, would appreciate help with that! 
