### PR TITLE
Allow swapping between boxZoom and boxCollector

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,8 @@ And the following custom handlers:
 
 <details><summary><code><b>boxCollector</b>: this</code></summary>
   <ul>
-    <li>Overrides the map's default <a href="https://leafletjs.com/reference-1.5.0.html#map-boxzoom"><code>boxZoom</code></a> handler.</li>
+    <li>Overrides the map's default <a href="https://leafletjs.com/reference-1.5.0.html#map-boxzoom"><code>boxZoom</code></a> handler. To use <code>boxZoom</code> instead, pass the options <code>{ boxCollector: false, boxZoom: true }</code> to the map on initialization.
+</li>
     <li>Allows multiple images to be collected when <kbd>shift</kbd> + <code>drag</code>ing on the map for the multiple image interface.</li>
   </ul>
 </details>

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -2607,7 +2607,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
       singleclickon: this._singleClickListeners,
       singleclickoff: this._resetClickListeners,
       singleclick: this._singleClick,
-      boxzoomend: this._addCollections,
+      boxcollectend: this._addCollections,
     }, this);
 
     this._group.editable = true;
@@ -2630,7 +2630,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
       singleclickon: this._singleClickListeners,
       singleclickoff: this._resetClickListeners,
       singleclick: this._singleClick,
-      boxzoomend: this._addCollections,
+      boxcollectend: this._addCollections,
     }, this);
 
     this._decollectAll();
@@ -2686,7 +2686,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
 
     if (e) { oe = e.originalEvent; }
     /**
-     * prevents image deselection following the 'boxzoomend' event - note 'shift' must not be released until dragging is complete
+     * prevents image deselection following the 'boxcollectend' event - note 'shift' must not be released until dragging is complete
      * also prevents deselection following a click on a disabled img by differentiating it from the map
      */
     if (oe && (oe.shiftKey || oe.target instanceof HTMLImageElement)) {
@@ -2730,7 +2730,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
   },
 
   _addCollections: function(e) {
-    var box = e.boxZoomBounds;
+    var box = e.boxCollectBounds;
     var map = this._group._map;
 
     this._group.eachLayer(function(layer) {
@@ -3273,7 +3273,7 @@ L.Map.BoxCollector = L.Map.BoxZoom.extend({
     // calls the `project` method but 1st updates the pixel origin - see https://github.com/publiclab/Leaflet.DistortableImage/pull/344
     bounds = this._map._latLngBoundsToNewLayerBounds(bounds, this._map.getZoom(), this._map.getCenter());
 
-    this._map.fire('boxzoomend', {boxZoomBounds: bounds});
+    this._map.fire('boxcollectend', {boxCollectBounds: bounds});
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-distortableimage",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-distortableimage",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Leaflet plugin enabling image overlays to be distorted, stretched, and warped (built for Public Lab's MapKnitter: http://publiclab.org).",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/edit/DistortableCollection.Edit.js
+++ b/src/edit/DistortableCollection.Edit.js
@@ -29,7 +29,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
       singleclickon: this._singleClickListeners,
       singleclickoff: this._resetClickListeners,
       singleclick: this._singleClick,
-      boxzoomend: this._addCollections,
+      boxcollectend: this._addCollections,
     }, this);
 
     this._group.editable = true;
@@ -52,7 +52,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
       singleclickon: this._singleClickListeners,
       singleclickoff: this._resetClickListeners,
       singleclick: this._singleClick,
-      boxzoomend: this._addCollections,
+      boxcollectend: this._addCollections,
     }, this);
 
     this._decollectAll();
@@ -108,7 +108,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
 
     if (e) { oe = e.originalEvent; }
     /**
-     * prevents image deselection following the 'boxzoomend' event - note 'shift' must not be released until dragging is complete
+     * prevents image deselection following the 'boxcollectend' event - note 'shift' must not be released until dragging is complete
      * also prevents deselection following a click on a disabled img by differentiating it from the map
      */
     if (oe && (oe.shiftKey || oe.target instanceof HTMLImageElement)) {
@@ -152,7 +152,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
   },
 
   _addCollections: function(e) {
-    var box = e.boxZoomBounds;
+    var box = e.boxCollectBounds;
     var map = this._group._map;
 
     this._group.eachLayer(function(layer) {

--- a/src/mapmixins/BoxCollector.js
+++ b/src/mapmixins/BoxCollector.js
@@ -127,7 +127,7 @@ L.Map.BoxCollector = L.Map.BoxZoom.extend({
     // calls the `project` method but 1st updates the pixel origin - see https://github.com/publiclab/Leaflet.DistortableImage/pull/344
     bounds = this._map._latLngBoundsToNewLayerBounds(bounds, this._map.getZoom(), this._map.getCenter());
 
-    this._map.fire('boxzoomend', {boxZoomBounds: bounds});
+    this._map.fire('boxcollectend', {boxCollectBounds: bounds});
   },
 });
 


### PR DESCRIPTION
Fixes #466  (<=== Add issue number here)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt`
* [ ] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached 📎 in case of UI updates
* [ ] @mention the original creator of the issue in a comment below for help or for a review

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!

# Summary

- allows enabling `boxZoom` instead of `boxCollector` and documents in README
- bumps minor version 0.8.7 -> 0.8.8