### PR TITLE
FIX: Remove loading spinner after image export

### DIFF
--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -2840,7 +2840,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
       }
 
       _fetchStatusUrl(opts.collection, opts.scale);
-    });
+    }.bind(this));
   },
 
   _addToolbar: function() {

--- a/dist/leaflet.distortableimage.js
+++ b/dist/leaflet.distortableimage.js
@@ -1617,7 +1617,12 @@ L.ExportAction = L.EditAction.extend({
       L.IconUtil.toggleXlink(this._link, 'get_app', 'spinner');
       L.IconUtil.toggleTitle(this._link, 'Export Images', 'Loading...');
       L.IconUtil.addClassToSvg(this._link, 'loader');
-      edit.startExport();
+
+      edit.startExport().then(function() {
+        L.IconUtil.toggleXlink(this._link, 'get_app', 'spinner');
+        L.IconUtil.toggleTitle(this._link, 'Export Images', 'Loading...');
+        L.DomUtil.removeClass(this._link.firstChild, 'loader');
+      }.bind(this));
     }
   },
 });
@@ -2770,68 +2775,72 @@ L.DistortableCollection.Edit = L.Handler.extend({
   },
 
   startExport: function(opts) {
-    opts = opts || {};
-    opts.collection = opts.collection || this._group.generateExportJson();
-    opts.frequency = opts.frequency || 3000;
-    opts.scale = opts.scale || 100; // switch it to _getAvgCmPerPixel !
-    var statusUrl;
-    var updateInterval;
+    return new Promise(function(resolve) {
+      opts = opts || {};
+      opts.collection = opts.collection || this._group.generateExportJson();
+      opts.frequency = opts.frequency || 3000;
+      opts.scale = opts.scale || 100; // switch it to _getAvgCmPerPixel !
+      var statusUrl;
+      var updateInterval;
 
-    // this may be overridden to update the UI to show export progress or completion
-    // eslint-disable-next-line require-jsdoc
-    function _defaultUpdater(data) {
-      data = JSON.parse(data);
-      // optimization: fetch status directly from google storage:
-      if (statusUrl !== data.status_url && data.status_url.match('.json')) {
-        statusUrl = data.status_url;
+      // this may be overridden to update the UI to show export progress or completion
+      // eslint-disable-next-line require-jsdoc
+      function _defaultUpdater(data) {
+        data = JSON.parse(data);
+        // optimization: fetch status directly from google storage:
+        if (statusUrl !== data.status_url && data.status_url.match('.json')) {
+          statusUrl = data.status_url;
+        }
+        if (data.status === 'complete') {
+          clearInterval(updateInterval);
+          resolve();
+        }
+        if (data.status === 'complete' && data.jpg !== null) {
+          alert('Export succeeded. http://export.mapknitter.org/' + data.jpg);
+        }
+        // TODO: update to clearInterval when status == "failed" if we update that in this file:
+        // https://github.com/publiclab/mapknitter-exporter/blob/main/lib/mapknitterExporter.rb
+        console.log(data);
       }
-      if (data.status === 'complete') {
-        clearInterval(updateInterval);
-      }
-      if (data.status === 'complete' && data.jpg !== null) {
-        alert('Export succeeded. http://export.mapknitter.org/' + data.jpg);
-      }
-      // TODO: update to clearInterval when status == "failed" if we update that in this file:
-      // https://github.com/publiclab/mapknitter-exporter/blob/main/lib/mapknitterExporter.rb
-      console.log(data);
-    }
 
-    // receives the URL of status.json, and starts running the updater to repeatedly fetch from status.json;
-    // this may be overridden to integrate with any UI
-    // eslint-disable-next-line require-jsdoc
-    function _defaultHandleStatusUrl(data) {
-      console.log(data);
-      statusUrl = '//export.mapknitter.org' + data;
-      opts.updater = opts.updater || _defaultUpdater;
+      // receives the URL of status.json, and starts running the updater to repeatedly fetch from status.json;
+      // this may be overridden to integrate with any UI
+      // eslint-disable-next-line require-jsdoc
+      function _defaultHandleStatusUrl(data) {
+        console.log(data);
+        statusUrl = '//export.mapknitter.org' + data;
+        opts.updater = opts.updater || _defaultUpdater;
 
-      // repeatedly fetch the status.json
-      updateInterval = setInterval(function intervalUpdater() {
-        $.ajax(statusUrl + '?' + Date.now(), {// bust cache with timestamp
-          type: 'GET',
+        // repeatedly fetch the status.json
+        updateInterval = setInterval(function intervalUpdater() {
+          $.ajax(statusUrl + '?' + Date.now(), {
+            // bust cache with timestamp
+            type: 'GET',
+            crossDomain: true
+          }).done(function(data) {
+            opts.updater(data);
+          });
+        }, opts.frequency);
+      }
+
+      // eslint-disable-next-line require-jsdoc
+      function _fetchStatusUrl(collection, scale) {
+        opts.handleStatusUrl = opts.handleStatusUrl || _defaultHandleStatusUrl;
+
+        $.ajax({
+          url: '//export.mapknitter.org/export',
           crossDomain: true,
-        }).done(function(data) {
-          opts.updater(data);
+          type: 'POST',
+          data: {
+            collection: JSON.stringify(collection.images),
+            scale: scale,
+          },
+          success: opts.handleStatusUrl, // this handles the initial response
         });
-      }, opts.frequency);
-    }
+      }
 
-    // eslint-disable-next-line require-jsdoc
-    function _fetchStatusUrl(collection, scale) {
-      opts.handleStatusUrl = opts.handleStatusUrl || _defaultHandleStatusUrl;
-
-      $.ajax({
-        url: '//export.mapknitter.org/export',
-        crossDomain: true,
-        type: 'POST',
-        data: {
-          collection: JSON.stringify(collection.images),
-          scale: scale,
-        },
-        success: opts.handleStatusUrl, // this handles the initial response
-      });
-    }
-
-    _fetchStatusUrl(opts.collection, opts.scale);
+      _fetchStatusUrl(opts.collection, opts.scale);
+    });
   },
 
   _addToolbar: function() {

--- a/examples/select.html
+++ b/examples/select.html
@@ -10,6 +10,8 @@
   <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" media="screen" title="no title">
   <script src="../node_modules/leaflet-toolbar/dist/leaflet.toolbar.js"></script>
   <link href="../node_modules/leaflet-toolbar/dist/leaflet.toolbar.css" rel="stylesheet">
+  <script src="../node_modules/promise-polyfill/dist/polyfill.min.js"></script>
+
 
   <!-- for full-res export -->
   <script src="../node_modules/jquery/dist/jquery.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5430,6 +5430,11 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "glfx": "0.0.4",
     "jquery": "~> 3.4.0",
     "leaflet-toolbar": "0.4.0-alpha.2",
+    "promise-polyfill": "^8.1.3",
     "webgl-distort": "0.0.2"
   },
   "devDependencies": {

--- a/src/edit/DistortableCollection.Edit.js
+++ b/src/edit/DistortableCollection.Edit.js
@@ -198,6 +198,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
     opts.scale = opts.scale || 100; // switch it to _getAvgCmPerPixel !
     var statusUrl;
     var updateInterval;
+    var link = this.toolbar._active._link;
 
     // this may be overridden to update the UI to show export progress or completion
     // eslint-disable-next-line require-jsdoc
@@ -209,6 +210,10 @@ L.DistortableCollection.Edit = L.Handler.extend({
       }
       if (data.status === 'complete') {
         clearInterval(updateInterval);
+
+        L.IconUtil.toggleXlink(link, 'get_app', 'spinner');
+        L.IconUtil.toggleTitle(link, 'Export Images', 'Loading...');
+        L.DomUtil.removeClass(link.firstChild, 'loader');
       }
       if (data.status === 'complete' && data.jpg !== null) {
         alert('Export succeeded. http://export.mapknitter.org/' + data.jpg);

--- a/src/edit/DistortableCollection.Edit.js
+++ b/src/edit/DistortableCollection.Edit.js
@@ -257,7 +257,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
       }
 
       _fetchStatusUrl(opts.collection, opts.scale);
-    });
+    }.bind(this));
   },
 
   _addToolbar: function() {

--- a/src/edit/DistortableCollection.Edit.js
+++ b/src/edit/DistortableCollection.Edit.js
@@ -192,7 +192,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
   },
 
   startExport: function(opts) {
-    return new Promise((resolve) => {
+    return new Promise(function(resolve) {
       opts = opts || {};
       opts.collection = opts.collection || this._group.generateExportJson();
       opts.frequency = opts.frequency || 3000;
@@ -250,9 +250,9 @@ L.DistortableCollection.Edit = L.Handler.extend({
           type: 'POST',
           data: {
             collection: JSON.stringify(collection.images),
-            scale: scale
+            scale: scale,
           },
-          success: opts.handleStatusUrl // this handles the initial response
+          success: opts.handleStatusUrl, // this handles the initial response
         });
       }
 

--- a/src/edit/DistortableCollection.Edit.js
+++ b/src/edit/DistortableCollection.Edit.js
@@ -192,73 +192,72 @@ L.DistortableCollection.Edit = L.Handler.extend({
   },
 
   startExport: function(opts) {
-    opts = opts || {};
-    opts.collection = opts.collection || this._group.generateExportJson();
-    opts.frequency = opts.frequency || 3000;
-    opts.scale = opts.scale || 100; // switch it to _getAvgCmPerPixel !
-    var statusUrl;
-    var updateInterval;
-    var link = this.toolbar._active._link;
+    return new Promise((resolve) => {
+      opts = opts || {};
+      opts.collection = opts.collection || this._group.generateExportJson();
+      opts.frequency = opts.frequency || 3000;
+      opts.scale = opts.scale || 100; // switch it to _getAvgCmPerPixel !
+      var statusUrl;
+      var updateInterval;
 
-    // this may be overridden to update the UI to show export progress or completion
-    // eslint-disable-next-line require-jsdoc
-    function _defaultUpdater(data) {
-      data = JSON.parse(data);
-      // optimization: fetch status directly from google storage:
-      if (statusUrl !== data.status_url && data.status_url.match('.json')) {
-        statusUrl = data.status_url;
+      // this may be overridden to update the UI to show export progress or completion
+      // eslint-disable-next-line require-jsdoc
+      function _defaultUpdater(data) {
+        data = JSON.parse(data);
+        // optimization: fetch status directly from google storage:
+        if (statusUrl !== data.status_url && data.status_url.match('.json')) {
+          statusUrl = data.status_url;
+        }
+        if (data.status === 'complete') {
+          clearInterval(updateInterval);
+          resolve();
+        }
+        if (data.status === 'complete' && data.jpg !== null) {
+          alert('Export succeeded. http://export.mapknitter.org/' + data.jpg);
+        }
+        // TODO: update to clearInterval when status == "failed" if we update that in this file:
+        // https://github.com/publiclab/mapknitter-exporter/blob/main/lib/mapknitterExporter.rb
+        console.log(data);
       }
-      if (data.status === 'complete') {
-        clearInterval(updateInterval);
 
-        L.IconUtil.toggleXlink(link, 'get_app', 'spinner');
-        L.IconUtil.toggleTitle(link, 'Export Images', 'Loading...');
-        L.DomUtil.removeClass(link.firstChild, 'loader');
+      // receives the URL of status.json, and starts running the updater to repeatedly fetch from status.json;
+      // this may be overridden to integrate with any UI
+      // eslint-disable-next-line require-jsdoc
+      function _defaultHandleStatusUrl(data) {
+        console.log(data);
+        statusUrl = '//export.mapknitter.org' + data;
+        opts.updater = opts.updater || _defaultUpdater;
+
+        // repeatedly fetch the status.json
+        updateInterval = setInterval(function intervalUpdater() {
+          $.ajax(statusUrl + '?' + Date.now(), {
+            // bust cache with timestamp
+            type: 'GET',
+            crossDomain: true
+          }).done(function(data) {
+            opts.updater(data);
+          });
+        }, opts.frequency);
       }
-      if (data.status === 'complete' && data.jpg !== null) {
-        alert('Export succeeded. http://export.mapknitter.org/' + data.jpg);
-      }
-      // TODO: update to clearInterval when status == "failed" if we update that in this file:
-      // https://github.com/publiclab/mapknitter-exporter/blob/main/lib/mapknitterExporter.rb
-      console.log(data);
-    }
 
-    // receives the URL of status.json, and starts running the updater to repeatedly fetch from status.json;
-    // this may be overridden to integrate with any UI
-    // eslint-disable-next-line require-jsdoc
-    function _defaultHandleStatusUrl(data) {
-      console.log(data);
-      statusUrl = '//export.mapknitter.org' + data;
-      opts.updater = opts.updater || _defaultUpdater;
+      // eslint-disable-next-line require-jsdoc
+      function _fetchStatusUrl(collection, scale) {
+        opts.handleStatusUrl = opts.handleStatusUrl || _defaultHandleStatusUrl;
 
-      // repeatedly fetch the status.json
-      updateInterval = setInterval(function intervalUpdater() {
-        $.ajax(statusUrl + '?' + Date.now(), {// bust cache with timestamp
-          type: 'GET',
+        $.ajax({
+          url: '//export.mapknitter.org/export',
           crossDomain: true,
-        }).done(function(data) {
-          opts.updater(data);
+          type: 'POST',
+          data: {
+            collection: JSON.stringify(collection.images),
+            scale: scale
+          },
+          success: opts.handleStatusUrl // this handles the initial response
         });
-      }, opts.frequency);
-    }
+      }
 
-    // eslint-disable-next-line require-jsdoc
-    function _fetchStatusUrl(collection, scale) {
-      opts.handleStatusUrl = opts.handleStatusUrl || _defaultHandleStatusUrl;
-
-      $.ajax({
-        url: '//export.mapknitter.org/export',
-        crossDomain: true,
-        type: 'POST',
-        data: {
-          collection: JSON.stringify(collection.images),
-          scale: scale,
-        },
-        success: opts.handleStatusUrl, // this handles the initial response
-      });
-    }
-
-    _fetchStatusUrl(opts.collection, opts.scale);
+      _fetchStatusUrl(opts.collection, opts.scale);
+    });
   },
 
   _addToolbar: function() {

--- a/src/edit/actions/ExportAction.js
+++ b/src/edit/actions/ExportAction.js
@@ -29,7 +29,12 @@ L.ExportAction = L.EditAction.extend({
       L.IconUtil.toggleXlink(this._link, 'get_app', 'spinner');
       L.IconUtil.toggleTitle(this._link, 'Export Images', 'Loading...');
       L.IconUtil.addClassToSvg(this._link, 'loader');
-      edit.startExport();
+
+      edit.startExport().then(() => {
+        L.IconUtil.toggleXlink(this._link, 'get_app', 'spinner');
+        L.IconUtil.toggleTitle(this._link, 'Export Images', 'Loading...');
+        L.DomUtil.removeClass(this._link.firstChild, 'loader');
+      });
     }
   },
 });

--- a/src/edit/actions/ExportAction.js
+++ b/src/edit/actions/ExportAction.js
@@ -30,11 +30,11 @@ L.ExportAction = L.EditAction.extend({
       L.IconUtil.toggleTitle(this._link, 'Export Images', 'Loading...');
       L.IconUtil.addClassToSvg(this._link, 'loader');
 
-      edit.startExport().then(() => {
+      edit.startExport().then(function() {
         L.IconUtil.toggleXlink(this._link, 'get_app', 'spinner');
         L.IconUtil.toggleTitle(this._link, 'Export Images', 'Loading...');
         L.DomUtil.removeClass(this._link.firstChild, 'loader');
-      });
+      }.bind(this));
     }
   },
 });


### PR DESCRIPTION
In the old UI, the spinner would continue spinning after the images have been
exported. Now it's fixed.

Resolves #470 

@sashadev-sky could you review this, please?