### PR TITLE
ADD: Custom translations functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,70 @@ Adds a control onto the map which opens a keymapper legend showing the available
 
 (WIP) Currently includes keybindings for all available actions and does not update yet if you use the `actions` API to limit available actions.
 
+### Custom Translations
+
+You can translate the LDI toolbar buttons in your native language by providing custom `translation` object to `distortableImageOverlay` or `distortableCollection`.
+
+**NOTE:** If you don't specify custom translation for certain field, it will fallback to English.
+
+These are the defaults:
+
+```javascript
+var translation = {
+    deleteImage: 'Delete Image',
+    deleteImages: 'Delete Images',
+    distortImage: 'Distort Image',
+    dragImage: 'Drag Image',
+    exportImage: 'Export Image',
+    exportImages: 'Export Images',
+    removeBorder: 'Remove Border',
+    addBorder: 'Add Border',
+    freeRotateImage: 'Free rotate Image',
+    geolocateImage: 'Geolocate Image',
+    lockMode: 'Lock Mode',
+    lockImages: 'Lock Images',
+    makeImageOpaque: 'Make Image Opaque',
+    makeImageTransparent: 'Make Image Transparent',
+    restoreOriginalImageDimensions: 'Restore Original Image Dimension',
+    rotateImage: 'Rotate Image',
+    scaleImage: 'Scale Image',
+    stackToFront: 'Stack to Front',
+    stackToBack: 'Stack to Back',
+    unlockImages: 'Unlock Images',
+    confirmImageDelete:
+    'Are you sure? This image will be permanently deleted from the map.',
+    confirmImagesDeletes:
+    'images will be permanently deleted from the map. Do you really want to do this?',
+};
+```
+
+**L.distortableImageOverlay**
+
+```javascript
+img = L.distortableImageOverlay('example.jpg', {
+    selected: true,
+    fullResolutionSrc: 'large.jpg',
+    translation: {
+        deleteImage: 'Obriši sliku',
+        distortImage: 'Izobliči sliku',
+        dragImage: 'Pomjeri sliku'
+        // ...
+    }
+}
+```
+
+**L.distortableCollection**
+
+```javascript
+imgGroup = L.distortableCollection({
+    translation: {
+        deleteImages: 'Obriši slike',
+        exportImages: 'Izvezi slike'
+        // ...
+    }
+})
+```
+
 ## Contributing
 
 There are [plenty of outstanding issues to resolve](https://github.com/publiclab/Leaflet.DistortableImage/issues). Please consider helping out!

--- a/src/DistortableCollection.js
+++ b/src/DistortableCollection.js
@@ -6,6 +6,7 @@ L.DistortableCollection = L.FeatureGroup.extend({
   initialize: function(options) {
     L.setOptions(this, options);
     L.FeatureGroup.prototype.initialize.call(this, options);
+    L.Utils.initTranslation.call(this);
 
     this.editable = this.options.editable;
   },

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -12,6 +12,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
 
   initialize: function(url, options) {
     L.setOptions(this, options);
+    L.Utils.initTranslation.call(this);
 
     this.edgeMinWidth = this.options.edgeMinWidth;
     this.editable = this.options.editable;

--- a/src/edit/actions/BorderAction.js
+++ b/src/edit/actions/BorderAction.js
@@ -7,10 +7,10 @@ L.BorderAction = L.EditAction.extend({
 
     if (edit._outlined) {
       use = 'border_outer';
-      tooltip = 'Remove Border';
+      tooltip = overlay.options.translation.removeBorder;
     } else {
       use = 'border_clear';
-      tooltip = 'Add Border';
+      tooltip = overlay.options.translation.addBorder;
     }
 
     options = options || {};

--- a/src/edit/actions/DeleteAction.js
+++ b/src/edit/actions/DeleteAction.js
@@ -8,13 +8,13 @@ L.DeleteAction = L.EditAction.extend({
       * the former should have `parentGroup` defined on it. From there we call the apporpriate keybindings and methods.
       */
     if (edit instanceof L.DistortableImage.Edit) {
-      tooltip = 'Delete Image';
+      tooltip = overlay.options.translation.deleteImage;
       // backspace windows / delete mac
       L.DistortableImage.action_map.Backspace = (
         edit._mode === 'lock' ? '' : '_removeOverlay'
       );
     } else {
-      tooltip = 'Delete Images';
+      tooltip = overlay.options.translation.deleteImages;
       L.DistortableImage.group_action_map.Backspace = (
         edit._mode === 'lock' ? '' : '_removeGroup'
       );

--- a/src/edit/actions/DistortAction.js
+++ b/src/edit/actions/DistortAction.js
@@ -4,7 +4,7 @@ L.DistortAction = L.EditAction.extend({
     options.toolbarIcon = {
       svg: true,
       html: 'distort',
-      tooltip: 'Distort Image',
+      tooltip: overlay.options.translation.distortImage,
       className: 'distort',
     };
 

--- a/src/edit/actions/DragAction.js
+++ b/src/edit/actions/DragAction.js
@@ -4,7 +4,7 @@ L.DragAction = L.EditAction.extend({
     options.toolbarIcon = {
       svg: true,
       html: 'drag',
-      tooltip: 'Drag Image',
+      tooltip: overlay.options.translation.dragImage,
       className: 'drag',
     };
 

--- a/src/edit/actions/ExportAction.js
+++ b/src/edit/actions/ExportAction.js
@@ -5,10 +5,10 @@ L.ExportAction = L.EditAction.extend({
 
     if (edit instanceof L.DistortableImage.Edit) {
       L.DistortableImage.action_map.e = '_getExport';
-      tooltip = 'Export Image';
+      tooltip = overlay.options.translation.exportImage;
     } else {
       L.DistortableImage.group_action_map.e = 'startExport';
-      tooltip = 'Export Images';
+      tooltip = overlay.options.translation.exportImages;
     }
 
     options = options || {};

--- a/src/edit/actions/FreeRotateAction.js
+++ b/src/edit/actions/FreeRotateAction.js
@@ -4,7 +4,7 @@ L.FreeRotateAction = L.EditAction.extend({
     options.toolbarIcon = {
       svg: true,
       html: 'crop_rotate',
-      tooltip: 'Free rotate Image',
+      tooltip: overlay.options.translation.freeRotateImage,
       className: 'freeRotate',
     };
 

--- a/src/edit/actions/GeolocateAction.js
+++ b/src/edit/actions/GeolocateAction.js
@@ -6,7 +6,7 @@ L.GeolocateAction = L.EditAction.extend({
     options.toolbarIcon = {
       svg: true,
       html: 'explore',
-      tooltip: 'Geolocate Image',
+      tooltip: overlay.options.translation.geolocateImage,
       className: edit._mode === 'lock' ? 'disabled' : '',
     };
 

--- a/src/edit/actions/LockAction.js
+++ b/src/edit/actions/LockAction.js
@@ -7,13 +7,13 @@ L.LockAction = L.EditAction.extend({
     if (edit instanceof L.DistortableImage.Edit) {
       L.DistortableImage.action_map.u = '_unlock';
       L.DistortableImage.action_map.l = '_lock';
-      tooltip = 'Lock Mode';
+      tooltip = overlay.options.translation.lockMode;
 
       if (edit._mode === 'lock') { use = 'lock'; }
       else { use = 'unlock'; }
     } else {
       L.DistortableImage.group_action_map.l = '_lockGroup';
-      tooltip = 'Lock Images';
+      tooltip = overlay.options.translation.lockImages;
       use = 'lock';
     }
 

--- a/src/edit/actions/OpacityAction.js
+++ b/src/edit/actions/OpacityAction.js
@@ -7,10 +7,10 @@ L.OpacityAction = L.EditAction.extend({
 
     if (edit._transparent) {
       use = 'opacity_empty';
-      tooltip = 'Make Image Opaque';
+      tooltip = overlay.options.translation.makeImageOpaque;
     } else {
       use = 'opacity';
-      tooltip = 'Make Image Transparent';
+      tooltip = overlay.options.translation.makeImageTransparent;
     }
 
     options = options || {};

--- a/src/edit/actions/RevertAction.js
+++ b/src/edit/actions/RevertAction.js
@@ -6,7 +6,7 @@ L.RevertAction = L.EditAction.extend({
     options.toolbarIcon = {
       svg: true,
       html: 'restore',
-      tooltip: 'Restore Original Image Dimensions',
+      tooltip: overlay.options.translation.restoreOriginalImageDimensions,
       className: edit._mode === 'lock' ? 'disabled' : '',
     };
 

--- a/src/edit/actions/RotateAction.js
+++ b/src/edit/actions/RotateAction.js
@@ -4,7 +4,7 @@ L.RotateAction = L.EditAction.extend({
     options.toolbarIcon = {
       svg: true,
       html: 'rotate',
-      tooltip: 'Rotate Image',
+      tooltip: overlay.options.translation.rotateImage,
       className: 'rotate',
     };
 

--- a/src/edit/actions/ScaleAction.js
+++ b/src/edit/actions/ScaleAction.js
@@ -4,7 +4,7 @@ L.ScaleAction = L.EditAction.extend({
     options.toolbarIcon = {
       svg: true,
       html: 'scale',
-      tooltip: 'Scale Image',
+      tooltip: overlay.options.translation.scaleImage,
       className: 'scale',
     };
 

--- a/src/edit/actions/StackAction.js
+++ b/src/edit/actions/StackAction.js
@@ -6,10 +6,10 @@ L.StackAction = L.EditAction.extend({
 
     if (edit._toggledImage) {
       use = 'flip_to_back';
-      tooltip = 'Stack to Front';
+      tooltip = overlay.options.translation.stackToFront;
     } else {
       use = 'flip_to_front';
-      tooltip = 'Stack to Back';
+      tooltip = overlay.options.translation.stackToBack;
     }
 
     options = options || {};

--- a/src/edit/toolbars/DistortableImage.ControlBar.js
+++ b/src/edit/toolbars/DistortableImage.ControlBar.js
@@ -9,7 +9,7 @@ L.UnlocksAction = L.EditAction.extend({
     options.toolbarIcon = {
       svg: true,
       html: 'unlock',
-      tooltip: 'Unlock Images',
+      tooltip: overlay.options.translation.unlockImages,
     };
 
     L.DistortableImage.group_action_map.u = '_unlockGroup';

--- a/src/util/DomUtil.js
+++ b/src/util/DomUtil.js
@@ -1,4 +1,8 @@
 L.DomUtil = L.extend(L.DomUtil, {
+  initTranslation: function(obj) {
+    this.translation = obj;
+  },
+
   getMatrixString: function(m) {
     var is3d = L.Browser.webkit3d || L.Browser.gecko3d || L.Browser.ie3d;
 
@@ -42,14 +46,17 @@ L.DomUtil = L.extend(L.DomUtil, {
   },
 
   confirmDelete: function() {
-    return window.confirm('Are you sure?' +
-      ' This image will be permanently deleted from the map.');
+    return window.confirm(this.translation.confirmImageDelete);
   },
 
   confirmDeletes: function(n) {
-    var humanized = n === 1 ? 'image' : 'images';
+    if (n === 1) {
+      this.confirmDelete();
+      return;
+    }
 
-    return window.confirm('Are you sure? ' + n +
-    ' ' + humanized + ' will be permanently deleted from the map.');
+    var warningMsg = n + ' ' + this.translation.confirmImagesDeletes;
+
+    return window.confirm(warningMsg);
   },
 });

--- a/src/util/Utils.js
+++ b/src/util/Utils.js
@@ -1,0 +1,43 @@
+L.Utils = {
+  initTranslation: function() {
+    var translation = {
+      deleteImage: 'Delete Image',
+      deleteImages: 'Delete Images',
+      distortImage: 'Distort Image',
+      dragImage: 'Drag Image',
+      exportImage: 'Export Image',
+      exportImages: 'Export Images',
+      removeBorder: 'Remove Border',
+      addBorder: 'Add Border',
+      freeRotateImage: 'Free rotate Image',
+      geolocateImage: 'Geolocate Image',
+      lockMode: 'Lock Mode',
+      lockImages: 'Lock Images',
+      makeImageOpaque: 'Make Image Opaque',
+      makeImageTransparent: 'Make Image Transparent',
+      restoreOriginalImageDimensions: 'Restore Original Image Dimension',
+      rotateImage: 'Rotate Image',
+      scaleImage: 'Scale Image',
+      stackToFront: 'Stack to Front',
+      stackToBack: 'Stack to Back',
+      unlockImages: 'Unlock Images',
+      confirmImageDelete:
+        'Are you sure? This image will be permanently deleted from the map.',
+      confirmImagesDeletes:
+        'images will be permanently deleted from the map. Do you really want to do this?',
+    };
+
+    if (!this.options.translation) {
+      this.options.translation = translation;
+    } else {
+      // If the translation for a word is not specified, fallback to English.
+      for (var key in translation) {
+        if (!this.options.translation.hasOwnProperty(key)) {
+          this.options.translation[key] = translation[key];
+        }
+      }
+    }
+
+    L.DomUtil.initTranslation(this.options.translation);
+  },
+};


### PR DESCRIPTION
We are getting closer to the stable API and one of the important features
is to allow developers to translate LDI in their native language.
This PR implements the requested feature.

[Demo](https://streamable.com/ahws5)

As you saw in the demo, it displays translations that are provided, but if there are no provided translations it will successfully fall back to English.

This approach is easily extensible since all you have to do when you add a new button/action to the toolbar is to open Utils.js and add a new entry in `translation` object.

Resolves #406

@sashadev-sky @rexagod @jywarren @SidharthBansal it would be great if you could review this :)
Thanks.