### PR TITLE
Allow moving of images at high zoom levels

### DIFF
--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -204,7 +204,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     return this;
   },
 
-  _cornerExceedsMapLats: function(zoom, corner) {
+  _cornerExceedsMapLats: function(zoom, corner, map) {
     var exceedsTop;
     var exceedsBottom;
     if (zoom === 0) {
@@ -225,7 +225,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
 
     // this is to fix https://github.com/publiclab/Leaflet.DistortableImage/issues/402
     for (var k in latlngObj) {
-      if (this._cornerExceedsMapLats(zoom, latlngObj[k])) {
+      if (this._cornerExceedsMapLats(zoom, latlngObj[k], map)) {
         // calling reset / update w/ the same corners bc it prevents a marker flicker for rotate
         this.setBounds(L.latLngBounds(this.getCorners()));
         this.fire('update');
@@ -257,7 +257,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     for (var k in pointsObj) {
       var corner = map.layerPointToLatLng(pointsObj[k]);
 
-      if (this._cornerExceedsMapLats(zoom, corner)) {
+      if (this._cornerExceedsMapLats(zoom, corner, map)) {
         // calling reset / update w/ the same corners bc it prevents a marker flicker for rotate
         this.setBounds(L.latLngBounds(this.getCorners()));
         this.fire('update');

--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -218,15 +218,18 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     var zoom = map.getZoom();
     var edit = this.editing;
     var i = 0;
+
+    //could be a problem here
+
     // this is to fix https://github.com/publiclab/Leaflet.DistortableImage/issues/402
-    for (var k in latlngObj) {
-      if (this._cornerExceedsMapLats(zoom, latlngObj[k])) {
-        // calling reset / update w/ the same corners bc it prevents a marker flicker for rotate
-        this.setBounds(L.latLngBounds(this.getCorners()));
-        this.fire('update');
-        return;
-      }
-    }
+    // for (var k in latlngObj) {
+    //   if (this._cornerExceedsMapLats(zoom, latlngObj[k])) {
+    //     // calling reset / update w/ the same corners bc it prevents a marker flicker for rotate
+    //     this.setBounds(L.latLngBounds(this.getCorners()));
+    //     this.fire('update');
+    //     return;
+    //   }
+    // }
 
     for (k in latlngObj) {
       this._corners[i] = latlngObj[k];


### PR DESCRIPTION
Fixes #446  

Here is a GIF demonstrating the moving of images at high zoom levels:

![DistortableImageZoomedInPreview](https://user-images.githubusercontent.com/37421108/72103864-b4327680-32ef-11ea-948b-9e71b8c3eef2.gif)

Here is a GIF demonstrating that the image still behaves normally when scaled to the size of the map, as noted in issue #402 :

![DistortableImageZoomedOutPreview](https://user-images.githubusercontent.com/37421108/72103377-ae886100-32ee-11ea-9315-3c5a092ce654.gif)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updates
* [x] @mention the original creator of the issue in a comment below for help or for a review

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
