### PR TITLE
ADD: Test for _calculateProjectiveTransform

### DIFF
--- a/test/src/DistortableImageOverlaySpec.js
+++ b/test/src/DistortableImageOverlaySpec.js
@@ -52,40 +52,40 @@ describe('L.DistortableImageOverlay', function() {
       overlay._map = map;
       overlay._initImage();
 
-      var latLngToLayerPoint = L.bind(map.latLngToLayerPoint, map);
+      var latLngToCartesian = L.bind(map.latLngToLayerPoint, map);
 
-      var matrix = overlay._calculateProjectiveTransform(latLngToLayerPoint);
+      var matrix = overlay._calculateProjectiveTransform(latLngToCartesian);
 
       // Compute matrix
-      var offset = latLngToLayerPoint(overlay._corners[0]);
+      var offset = latLngToCartesian(overlay._corners[0]);
+      // Offset width (image's width, including padding and borders)
       var w = overlay._image.offsetWidth || 500;
+      // Offset height (image's height, including padding and borders)
       var h = overlay._image.offsetHeight || 375;
+      // An array of objects containing cartesian coordinates { x: <num>, y: <num> }
+      // Each object represents the coordinate of one of 4 corners of the image
       var c = [];
-      var j;
 
-      for (j = 0; j < overlay._corners.length; j++) {
-        c.push(latLngToLayerPoint(overlay._corners[j])._subtract(offset));
+
+      for (var j = 0; j < overlay._corners.length; j++) {
+        // Convert image corner's geocoordinates(lat & lng) to cartesian coordinates(x & y)
+        // From each corner substract the base offset coordinates
+        c.push(latLngToCartesian(overlay._corners[j])._subtract(offset));
       }
 
+      // Homogeneous transformation matrix
+      // Each row represents a CSS transformation on each corner
       var computedMatrix = L.MatrixUtil.general2DProjection(
-        0,
-        0,
-        c[0].x,
-        c[0].y,
-        w,
-        0,
-        c[1].x,
-        c[1].y,
-        0,
-        h,
-        c[2].x,
-        c[2].y,
-        w,
-        h,
-        c[3].x,
-        c[3].y
+        // The image is always placed to the top left corner because the first row is always 0,0,0,0
+        // The first 2 numbers represent the base position (origin), and the second 2 numbers
+        // represent the postion that it maps to
+        0, 0, c[0].x, c[0].y,
+        w, 0, c[1].x, c[1].y,
+        0, h, c[2].x, c[2].y,
+        w, h, c[3].x, c[3].y
       );
 
+      // LEARN MORE: https://publiclab.org/notes/justinmanley/05-21-2015/the-magic-behind-mapknitter-leaflet-distortableimage
       expect(matrix).to.eql(computedMatrix);
     });
   });

--- a/test/src/DistortableImageOverlaySpec.js
+++ b/test/src/DistortableImageOverlaySpec.js
@@ -46,16 +46,47 @@ describe('L.DistortableImageOverlay', function() {
     });
   });
 
-  describe('#_calculateProjectiveTransform', function() {
-    it.skip('Should', function() {
-      var matrix;
-
+  describe("#_calculateProjectiveTransform", function() {
+    it("Should correctly calculate projective transform matrix", function() {
       /* _map is set when #onAdd is called. */
       overlay._map = map;
       overlay._initImage();
 
-      matrix = overlay._calculateProjectiveTransform();
-      expect(matrix).to.equal([]);
+      var latLngToLayerPoint = L.bind(map.latLngToLayerPoint, map);
+
+      var matrix = overlay._calculateProjectiveTransform(latLngToLayerPoint);
+
+      // Compute matrix
+      var offset = latLngToLayerPoint(overlay._corners[0]);
+      var w = overlay._image.offsetWidth || 500;
+      var h = overlay._image.offsetHeight || 375;
+      var c = [];
+      var j;
+
+      for (j = 0; j < overlay._corners.length; j++) {
+        c.push(latLngToLayerPoint(overlay._corners[j])._subtract(offset));
+      }
+
+      var computedMatrix = L.MatrixUtil.general2DProjection(
+        0,
+        0,
+        c[0].x,
+        c[0].y,
+        w,
+        0,
+        c[1].x,
+        c[1].y,
+        0,
+        h,
+        c[2].x,
+        c[2].y,
+        w,
+        h,
+        c[3].x,
+        c[3].y
+      );
+
+      expect(matrix).to.eql(computedMatrix);
     });
   });
 


### PR DESCRIPTION
The hardest part here was to figure out how to expose `latLngToLayerPoint`.
This test is made to be bulletproof, the core logic is in it. 
If you decide to refactor ` _calculateProjectiveTransform` in the future, it will show if it's correct or not.

Resolves #484 

@sashadev-sky your opinion on this?