### PR TITLE
add opts.resolve to allow stopping export spinner from user-defined functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-distortableimage",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Leaflet plugin enabling image overlays to be distorted, stretched, and warped (built for Public Lab's MapKnitter: http://publiclab.org).",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/edit/DistortableCollection.Edit.js
+++ b/src/edit/DistortableCollection.Edit.js
@@ -260,6 +260,7 @@ L.DistortableCollection.Edit = L.Handler.extend({
   startExport: function() {
     return new Promise(function(resolve) {
       var opts = this._exportOpts;
+      opts.resolve = resolve; // allow resolving promise in user-defined functions, to stop spinner on completion
       var statusUrl;
       var self = this;
       this.updateInterval = null;


### PR DESCRIPTION
Thinking this may help https://github.com/publiclab/mapknitter/pull/1192