### PR TITLE
Update L.DragHandle initializer to class factory syntax

### DIFF
--- a/src/edit/DistortableImage.Edit.js
+++ b/src/edit/DistortableImage.Edit.js
@@ -97,7 +97,7 @@ L.DistortableImage.Edit = L.Handler.extend({
 
     this._dragHandles = L.layerGroup();
     for (i = 0; i < 4; i++) {
-      this._dragHandles.addLayer(new L.DragHandle(overlay, i));
+      this._dragHandles.addLayer(L.dragHandle(overlay, i));
     }
 
     this._scaleHandles = L.layerGroup();

--- a/src/edit/handles/DragHandle.js
+++ b/src/edit/handles/DragHandle.js
@@ -21,3 +21,7 @@ L.DragHandle = L.EditHandle.extend({
     this.setLatLng(this._handled.getCorner(this._corner));
   },
 });
+
+L.dragHandle = function(overlay, idx, options) {
+  return new L.DragHandle(overlay, idx, options);
+};


### PR DESCRIPTION
Fixes https://github.com/publiclab/Leaflet.DistortableImage/issues/582

Update L.DragHandle initializer to class factory syntax


