### PR TITLE
Displayed url of image origin, in MapKnitter Lite interface

### DIFF
--- a/examples/archive.html
+++ b/examples/archive.html
@@ -95,6 +95,7 @@
     form.addEventListener('submit', (event) => {
       event.preventDefault();
       const url = input.value.replace('details', 'metadata');
+      let fetchedFrom
       axios.get(url)
         .then((response) => {
           if (response.data.files && response.data.files.length != 0) {
@@ -104,6 +105,12 @@
                 let imageRow = document.createElement('div');
                 let image = new Image(150, 150);
                 let placeButton = document.createElement('a');
+                fetchedFrom = document.createElement('p');
+                fetchedFromUrl = document.createElement('a');
+                fetchedFromUrl.setAttribute('href', input.value);
+                fetchedFromUrl.setAttribute('target', '_blank');
+                fetchedFromUrl.innerHTML = 'this Internet Archive Collection';
+                fetchedFrom.appendChild(fetchedFromUrl)
 
                 placeButton.classList.add('btn', 'btn-sm', 'btn-outline-secondary', 'place-button');
                 placeButton.innerHTML = 'Place on map';
@@ -117,7 +124,7 @@
                 imageCount++;
               }
             });
-            responseText.innerHTML = imageCount ? `${imageCount} image(s) fetched successfully.` : 'No images found in the link provided...'
+            responseText.innerHTML = imageCount ? `${imageCount} image(s) fetched successfully from ${fetchedFrom.innerHTML}.` : 'No images found in the link provided...'
           } else {
             responseText.innerHTML = 'No images found in the link provided...'
           }


### PR DESCRIPTION
## Fixes #[1153](https://github.com/publiclab/Leaflet.DistortableImage/issues/1153)

### Screenshot
![image-Url-UI](https://user-images.githubusercontent.com/75104021/195741971-4113a65c-f3de-4e61-aad3-b3cb9c78a855.png)

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt test`
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updates
* [x] @mention the original creator of the issue in a comment below for help or for a review

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software 

Thanks!
