### PR TITLE
Changing var keyword to const

### DIFF
--- a/src/edit/toolbars/DistortableImage.ControlBar.js
+++ b/src/edit/toolbars/DistortableImage.ControlBar.js
@@ -25,7 +25,7 @@ L.DistortableCollection.addInitHook(function() {
     unlock: L.UnlockAction,
   };
 
-  var a = this.options.actions ? this.options.actions : this.ACTIONS;
+  const a = this.options.actions ? this.options.actions : this.ACTIONS;
 
   this.editing = L.distortableCollection.edit(this, {actions: a});
 });


### PR DESCRIPTION
@TildaDares  this is my pull request 
fixes #1086 
Changed var keyword to  const keyword in DistortableImage.ControlBar.js in line 28