### PR TITLE
Web Accessibility of Leaflet.DistortableImage.

### DIFF
--- a/examples/archive.html
+++ b/examples/archive.html
@@ -19,51 +19,50 @@
   </head>
 
   <body style="margin:0;">
-    
-    <div class="modal fade" id="welcomeModal" aria-labelledby="exampleModalLabel" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
-        <div class="modal-content bg-light">
-          <div class="modal-header d-block">
-            <div class="d-flex justify-content-between align-items-center">
-              <h2 class="modal-title">Welcome to MapKnitter Lite</h2>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+
+  <main>
+      <div class="modal fade" id="welcomeModal" aria-labelledby="exampleModalLabel" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+          <div class="modal-content bg-light">
+            <div class="modal-header d-block">
+              <div class="d-flex justify-content-between align-items-center">
+                <h2 class="modal-title">Welcome to MapKnitter Lite</h2>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              </div>
+              <p> <small>(while MapKnitter is offline)</small> </p>
             </div>
-            <p> <small>(while MapKnitter is offline)</small> </p>
-          </div>
-          <div class="modal-body">
-            <p>First, you’ll need to go to <a href="https://archive.org/" target="_blank">archive.org</a>, create an account, and then upload your images.
-              <a href="https://archive.org/embed/help-upload-overview" target="_blank">Watch this helpful video guide.</a>
-            </p>
-            <p>You’ll get an address that looks like this:
-              <a href="https://archive.org/details/texas-barnraising/" target="_blank">
-                https://archive.org/details/texas-barnraising/
-              </a>
-            </p>
-            <p>Paste it here to begin:</p>
-            <form id="form">
-              <input id="input" type="text" class="form-control" placeholder="https://archive.org/details/..." required>
-              <button type="submit" class="btn btn-primary mt-4 mb-5">Begin</button>
-            </form>
+            <div class="modal-body">
+              <p>First, you’ll need to go to <a href="https://archive.org/" target="_blank">archive.org</a>, create an account, and then upload your images.
+                <a href="https://archive.org/embed/help-upload-overview" target="_blank">Watch this helpful video guide.</a>
+              </p>
+              <p>You’ll get an address that looks like this:
+                <a href="https://archive.org/details/texas-barnraising/" target="_blank">
+                  https://archive.org/details/texas-barnraising/
+                </a>
+              </p>
+              <p>Paste it here to begin:</p>
+              <form id="form">
+                <input id="input" type="text" class="form-control" placeholder="https://archive.org/details/..." required>
+                <button type="submit" class="btn btn-primary mt-4 mb-5">Begin</button>
+              </form>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-
-    <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
-
-    <div class="offcanvas offcanvas-end" data-bs-backdrop="false" data-bs-keyboard="false" tabindex="1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
-      <div class="offcanvas-header">
-        <h3 id="offcanvasRightLabel">Images</h3>
-        <button type="button" class="btn btn-primary d-sm-none" data-bs-dismiss="offcanvas" aria-label="Close">View Map</button>
+      <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
+      <div class="offcanvas offcanvas-end" data-bs-backdrop="false" data-bs-keyboard="false" tabindex="1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
+        <div class="offcanvas-header">
+          <h3 id="offcanvasRightLabel">Images</h3>
+          <button type="button" class="btn btn-primary d-sm-none" data-bs-dismiss="offcanvas" aria-label="Close">View Map</button>
+        </div>
+        <hr>
+        <div class="offcanvas-body">
+          <p id="response" class="mb-5">No link = No images...</p>
+          <div id="imgContainer"></div>
+        </div>
       </div>
-      <hr>
-      <div class="offcanvas-body">
-        <p id="response" class="mb-5">No link = No images...</p>
-        <div id="imgContainer"></div>
-      </div>
-    </div>
-  </body>
-
+  </main>
+    
   <script>
     let map;
     let welcomeModal = document.getElementById('welcomeModal');
@@ -142,4 +141,7 @@
       }
     });
   </script>
+    
+  </body>
 </html>
+

--- a/examples/export.html
+++ b/examples/export.html
@@ -14,13 +14,16 @@
   <script src="../dist/vendor.js"></script>
   <script src="../dist/leaflet.distortableimage.js"></script>
 </head>
+
 <body style="margin:0;">
 
-  <form id="test_form" >
-    <input type="file" class="ldi" id="inputimage" accept="image/*">
-  </form>
-
-  <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
+  <main>
+    <form id="test_form" >
+      <input type="file" class="ldi" id="inputimage" accept="image/*">
+    </form>
+  
+    <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
+  </main>
 
   <script>
     let map;
@@ -144,4 +147,6 @@
       });
     })();
   </script>
+    
+</body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -14,13 +14,16 @@
     <script src="../dist/vendor.js"></script>
     <script src="../dist/leaflet.distortableimage.js"></script>
   </head>
-  <body style="margin:0;">
-    <form id="test_form">
-      <input type="file" class="ldi" id="inputimage" accept="image/*" />
-    </form>
 
-    <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
-  </body>
+  <body style="margin:0;">
+    <main>
+      <form id="test_form">
+        <input type="file" class="ldi" id="inputimage" accept="image/*" />
+      </form>
+  
+      <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
+    </main>
+  
   <script>
     let map;
 
@@ -36,4 +39,6 @@
       });
     })();
   </script>
+
+  </body>
 </html>

--- a/examples/listeners.html
+++ b/examples/listeners.html
@@ -16,11 +16,13 @@
 </head>
 <body style="margin:0;">
 
-  <form id="test_form" >
-    <input type="file" class="ldi" id="inputimage" accept="image/*">
-  </form>
-
-  <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
+  <main>
+    <form id="test_form" >
+      <input type="file" class="ldi" id="inputimage" accept="image/*">
+    </form>
+  
+    <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
+  </main>
 
   <script>
     var map;
@@ -42,4 +44,6 @@
       });
     })();
   </script>
+    
+  </body>
 </html>

--- a/examples/select.html
+++ b/examples/select.html
@@ -14,13 +14,16 @@
   <script src="../dist/vendor.js"></script>
   <script src="../dist/leaflet.distortableimage.js"></script>
 </head>
+
 <body style="margin:0;">
 
-  <form id="test_form" >
-    <input type="file" class="ldi" id="inputimage" accept="image/*">
-  </form>
-
-  <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
+  <main>
+    <form id="test_form" >
+      <input type="file" class="ldi" id="inputimage" accept="image/*">
+    </form>
+  
+    <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
+  </main>
 
   <script>
     let map;
@@ -82,4 +85,6 @@
       });
     })();
   </script>
+
+</body>
 </html>


### PR DESCRIPTION
I added the body closing tag for some of the html files, and I  also worked on the general accessibility of all html files (archive.html, export.html, index.html, listeners.html, select.html) in the repo: https://github.com/publiclab/Leaflet.DistortableImage/tree/main/examples

Fixes #11494

![archive](https://user-images.githubusercontent.com/102672669/197722778-0932d329-534e-4ca5-8573-c8dbf9a42e68.JPG)
![export](https://user-images.githubusercontent.com/102672669/197722797-42f81690-a0d4-456b-b402-3cffe61044f7.JPG)
![index](https://user-images.githubusercontent.com/102672669/197722811-1ca2c52d-6ca7-4a0f-bfa0-202ad949033e.JPG)
![listeners](https://user-images.githubusercontent.com/102672669/197722815-c7e1fe1f-6b7b-49d2-9d5a-dc1168df6a86.JPG)
![select](https://user-images.githubusercontent.com/102672669/197722822-1c5c2137-d760-4365-b6ad-42d314c0df4a.JPG)


