### PR TITLE
Change nameless functions to arrow functions

### DIFF
--- a/test/src/edit/DistortableCollectionEditSpec.js
+++ b/test/src/edit/DistortableCollectionEditSpec.js
@@ -1,7 +1,7 @@
-describe('L.DistortableCollection.Edit', function() {
+describe('L.DistortableCollection.Edit', () => {
   let map; let overlay; let overlay2; let overlay3; let imgGroup;
 
-  beforeEach(function(done) {
+  beforeEach((done) => {
     map = L.map(L.DomUtil.create('div', '', document.body)).setView([41.7896, -87.5996], 15);
 
     overlay = L.distortableImageOverlay('/examples/example.jpg', {
@@ -38,17 +38,17 @@ describe('L.DistortableCollection.Edit', function() {
     imgGroup.addLayer(overlay3);
 
     /* Forces the images to load before any tests are run. */
-    L.DomEvent.on(overlay3, 'load', function() { done(); });
+    L.DomEvent.on(overlay3, 'load', () => { done(); });
   });
 
-  afterEach(function() {
+  afterEach(() => {
     imgGroup.removeLayer(overlay);
     imgGroup.removeLayer(overlay2);
     imgGroup.removeLayer(overlay3);
   });
 
-  describe('#_decollectAll', function() {
-    it('Should remove the \'selected\' class from all images', function() {
+  describe('#_decollectAll', () => {
+    it('Should remove the \'selected\' class from all images', () => {
       const img = overlay.getElement();
       const img2 = overlay2.getElement();
 
@@ -58,13 +58,13 @@ describe('L.DistortableCollection.Edit', function() {
       map.getContainer().click();
 
       // we deselect after 3ms to confirm the click wasn't a dblclick
-      setTimeout(function() {
+      setTimeout(() => {
         expect(L.DomUtil.getClass(img)).to.not.include('collected');
         expect(L.DomUtil.getClass(img2)).to.not.include('collected');
       }, 3000);
     });
 
-    it('Should hide all images\' handles unless they\'re lock handles', function() {
+    it('Should hide all images\' handles unless they\'re lock handles', () => {
       const edit = overlay.editing;
       const edit2 = overlay2.editing;
       const distortHandleState = [];
@@ -76,13 +76,13 @@ describe('L.DistortableCollection.Edit', function() {
       // then trigger _decollectAll
       map.getContainer().click();
 
-      setTimeout(function() {
-        edit._handles.distort.eachLayer(function(handle) {
+      setTimeout(() => {
+        edit._handles.distort.eachLayer((handle) => {
           const icon = handle.getElement();
           distortHandleState.push(L.DomUtil.getStyle(icon, 'opacity'));
         });
 
-        edit2._handles.lock.eachLayer(function(handle) {
+        edit2._handles.lock.eachLayer((handle) => {
           const icon = handle.getElement();
           lockHandleState.push(L.DomUtil.getStyle(icon, 'opacity'));
         });
@@ -93,7 +93,7 @@ describe('L.DistortableCollection.Edit', function() {
       }, 3000);
     });
 
-    it('Should remove an image\'s individual toolbar instances regardless of lock handles', function() {
+    it('Should remove an image\'s individual toolbar instances regardless of lock handles', () => {
       const edit2 = overlay2.editing;
 
       edit2._toggleLockMode();
@@ -106,14 +106,14 @@ describe('L.DistortableCollection.Edit', function() {
       // then trigger _decollectAll
       map.getContainer().click();
 
-      setTimeout(function() {
+      setTimeout(() => {
         expect(edit2.toolbar).to.be.false;
       }, 3000);
     });
   });
 
-  describe('#_addToolbar', function() {
-    it('is invoked on the click event that follows mousedown multi-select', function() {
+  describe('#_addToolbar', () => {
+    it('is invoked on the click event that follows mousedown multi-select', () => {
       expect(map._toolbars).to.be.empty;
 
       // need both bc simulated `mousedown`s don't fire `click` events afterwards like regular user generated `mousedown`s.
@@ -123,14 +123,14 @@ describe('L.DistortableCollection.Edit', function() {
       expect(Object.keys(map._toolbars)).to.have.lengthOf(1);
     });
 
-    it('it adds a control toolbar to the map', function() {
+    it('it adds a control toolbar to the map', () => {
       expect(map._toolbars).to.be.empty;
       imgGroup.editing._addToolbar();
       expect(Object.keys(map._toolbars)).to.have.lengthOf(1);
       expect(Object.keys(map._toolbars)[0]._container).className = 'leaflet-control';
     });
 
-    it('does not add multiple instances of a control toolbar', function() {
+    it('does not add multiple instances of a control toolbar', () => {
       expect(map._toolbars).to.be.empty;
       imgGroup.editing._addToolbar();
       imgGroup.editing._addToolbar();
@@ -138,59 +138,59 @@ describe('L.DistortableCollection.Edit', function() {
     });
   });
 
-  describe('#_removeToolbar', function() {
-    beforeEach(function() { // multi-select the image and add the toolbar
+  describe('#_removeToolbar', () => {
+    beforeEach(() => { // multi-select the image and add the toolbar
       chai.simulateEvent(overlay.getElement(), 'mousedown', {shiftKey: true});
       imgGroup.editing._addToolbar();
 
       expect(Object.keys(map._toolbars)).to.have.lengthOf(1);
     });
 
-    it('is invoked on map click', function() {
+    it('is invoked on map click', () => {
       map.getContainer().click();
-      setTimeout(function() {
+      setTimeout(() => {
         expect(map._toolbars).to.be.empty;
       }, 3000);
     });
 
-    it('is invoked on shift + mousedown when it toggles the image *out* of multi-select', function() {
+    it('is invoked on shift + mousedown when it toggles the image *out* of multi-select', () => {
       // deselecting the image removes the control toolbar
       chai.simulateEvent(overlay.getElement(), 'mousedown', {shiftKey: true});
       expect(map._toolbars).to.be.empty;
     });
 
-    it('it removes a control toolbar from the map', function() {
+    it('it removes a control toolbar from the map', () => {
       imgGroup.editing._removeToolbar();
       expect(map._toolbars).to.be.empty;
     });
 
-    it('it returns false if there was no control toolbar to remove', function() {
+    it('it returns false if there was no control toolbar to remove', () => {
       expect(imgGroup.editing._removeToolbar()).to.not.be.false;
       expect(imgGroup.editing._removeToolbar()).to.be.false;
     });
   });
 
-  describe('#_lockGroup', function() {
-    beforeEach(function() {
+  describe('#_lockGroup', () => {
+    beforeEach(() => {
       chai.simulateEvent(overlay.getElement(), 'mousedown', {shiftKey: true});
       chai.simulateEvent(overlay3.getElement(), 'mousedown', {shiftKey: true});
 
       imgGroup.editing._lockGroup();
     });
 
-    it('it only puts the multi-selected images in lock mode', function() {
+    it('it only puts the multi-selected images in lock mode', () => {
       expect(overlay.editing._mode).to.equal('lock');
       expect(overlay3.editing._mode).to.equal('lock');
 
       expect(overlay2.editing._mode).to.not.equal('lock');
     });
 
-    it('does not toggle lock mode', function() {
+    it('does not toggle lock mode', () => {
       imgGroup.editing._lockGroup();
       expect(overlay.editing._mode).to.equal('lock');
     });
 
-    it('prevents images in that group from being dragged', function() {
+    it('prevents images in that group from being dragged', () => {
       expect(overlay.editing.dragging).to.be.undefined;
       expect(overlay3.editing.dragging).to.be.undefined;
 
@@ -198,8 +198,8 @@ describe('L.DistortableCollection.Edit', function() {
     });
   });
 
-  describe('#_unlockGroup', function() {
-    beforeEach(function() {
+  describe('#_unlockGroup', () => {
+    beforeEach(() => {
       chai.simulateEvent(overlay.getElement(), 'mousedown', {shiftKey: true});
       chai.simulateEvent(overlay2.getElement(), 'mousedown', {shiftKey: true});
       chai.simulateEvent(overlay3.getElement(), 'mousedown', {shiftKey: true});
@@ -208,25 +208,25 @@ describe('L.DistortableCollection.Edit', function() {
       expect(overlay.editing._mode).to.equal('lock');
     });
 
-    it('it removes the multi-selected images from lock mode', function() {
+    it('it removes the multi-selected images from lock mode', () => {
       imgGroup.editing._unlockGroup();
       expect(overlay.editing._mode).to.not.equal('lock');
     });
 
-    it('does not toggle lock mode', function() {
+    it('does not toggle lock mode', () => {
       imgGroup.editing._unlockGroup();
       imgGroup.editing._unlockGroup();
       expect(overlay.editing._mode).to.not.equal('lock');
     });
   });
 
-  describe('#_removeGroup', function() {
-    beforeEach(function() { // multi-selects the images to add them to the feature group
+  describe('#_removeGroup', () => {
+    beforeEach(() => { // multi-selects the images to add them to the feature group
       chai.simulateEvent(overlay.getElement(), 'mousedown', {shiftKey: true});
       chai.simulateEvent(overlay3.getElement(), 'mousedown', {shiftKey: true});
     });
 
-    it('removes a collection of layers', function() {
+    it('removes a collection of layers', () => {
       const layers = imgGroup.getLayers();
       expect(layers).to.include.members([overlay, overlay2, overlay3]);
 
@@ -236,7 +236,7 @@ describe('L.DistortableCollection.Edit', function() {
       expect(layers).to.include.members([overlay2]);
     });
 
-    it('removes the layers from the map on removal from group', function() {
+    it('removes the layers from the map on removal from group', () => {
       const id = imgGroup.getLayerId(overlay);
       const id2 = imgGroup.getLayerId(overlay2);
       const id3 = imgGroup.getLayerId(overlay3);


### PR DESCRIPTION
Fixes #1235

Made sure these boxes are checked before the pull request (PR) is ready to be reviewed and merged.

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt test`
* [x] code is in a uniquely-named feature branch and has no merge conflicts 📁
* [x] @Achele, @TildaDares I have implemented the fix, and I would like to get a review.

## Requirements

* [x] Refactored nameless functions in [DistortableCollectionEditSpec.js](https://github.com/publiclab/Leaflet.DistortableImage/blob/main/test/src/edit/DistortableCollectionEditSpec.js) to arrow functions.