### PR TITLE
infoBar toggle

### DIFF
--- a/examples/js/local.js
+++ b/examples/js/local.js
@@ -3,7 +3,6 @@ const infoBtn = document.getElementById('infoBtn');
 const infoBar = document.getElementById('main');
 
 infoBtn.addEventListener('click', () => {
-  console.log(infoBar.classList);
   if (infoBar.classList.contains('close')) {
     infoBar.classList.remove('close');
   } else {

--- a/examples/js/local.js
+++ b/examples/js/local.js
@@ -1,3 +1,15 @@
+// handle info open and close
+const infoBtn = document.getElementById('infoBtn');
+const infoBar = document.getElementById('main');
+
+infoBtn.addEventListener('click', () => {
+  console.log(infoBar.classList);
+  if (infoBar.classList.contains('close')) {
+    infoBar.classList.remove('close');
+  } else {
+    infoBar.classList.add('close');
+  }
+});
 
 const uploadFiles = () => {
   const dropZone = document.getElementById('dropZone');

--- a/examples/local.css
+++ b/examples/local.css
@@ -19,7 +19,6 @@
 
      .close{
       right: -620px;
-
      }
      
     .archive {

--- a/examples/local.css
+++ b/examples/local.css
@@ -12,14 +12,16 @@
       position: relative;
       z-index: 1000;
       position: fixed; 
-      bottom: 5%;
-      right: 0;
+      bottom: 40px;
+      right: 0px;     
+      transition: all 1s ease-out;
      }
 
-    .openbar a:hover {
-      color: #f1f1f1;
-    }
+     .close{
+      right: -620px;
 
+     }
+     
     .archive {
       font-size: 16px;
       font-family: 'Courier New', Courier, monospace;
@@ -28,10 +30,19 @@
       color: #111;
       padding: 10px 10px;
       border: solid 1px black;
+      display: flex;
+      align-items: center;
     }
     .archive a:hover{
       color:rgb(6, 200, 6)
     }
+    .archive div {
+      margin-left: 10px;
+    }
+    .archive div p{
+      margin: 0;
+    }
+
     
      #info {
       position: fixed;

--- a/examples/local.html
+++ b/examples/local.html
@@ -29,9 +29,14 @@
         <div id="dropZone" class="flex-item flex-item1">
           <div id="map" style="width:100%; height:100%; position:absolute; top:0;"></div>
         </div> 
-        <div id="info"><h1>DRAG FILES HERE TO EDIT</h1></div>
-          <div id="main" class="openbar">
-            <p class="archive"><a  href="archive.html" target="_blank">Click here</a> to use Archive.org to store and share the map online</p>
-          </div>
+          <section id="main" class="openbar">
+            <div class="archive">
+               <i title="Open/Close info" id="infoBtn" class="fa fa-bars fa-2x " style=" color: black; cursor: pointer;" aria-hidden="true"></i>
+               <div>
+                 <p>Drag and Drop image on the map.</p> 
+                <p> <a  href="archive.html" target="_blank">Click here</a> to use Archive.org to store and share the map online</p>
+               </div>
+            </div>
+          </section>
    </body>
 </html>


### PR DESCRIPTION
Based on the review comment here: https://github.com/publiclab/Leaflet.DistortableImage/pull/1293#issuecomment-1351772834
I included a toggle open and close button, with all functionality retained

#### Here is the UI:

![infoBar](https://user-images.githubusercontent.com/75104021/207700027-27ab88e7-15ca-4bc7-84a9-d17a5cb0a56f.gif)

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt test`
* [x] code is in a uniquely-named feature branch and has no merge conflicts 📁
* [x] screenshots/GIFs are attached 📎 in case of UI updates
* [x] @mention the original creator of the issue in a comment below for help or for a review
