### PR TITLE
Fix error when removing image while loading

### DIFF
--- a/src/DistortableImageOverlay.js
+++ b/src/DistortableImageOverlay.js
@@ -39,35 +39,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
     }
 
     // Have to wait for the image to load because need to access its w/h
-    L.DomEvent.on(this.getElement(), 'load', () => {
-      this.getPane().appendChild(this.getElement());
-      this._initImageDimensions();
-
-      if (this.options.rotation) {
-        const units = this.options.rotation.deg >= 0 ? 'deg' : 'rad';
-        this.setAngle(this.options.rotation[units], units);
-      } else {
-        this.rotation = {deg: 0, rad: 0};
-        this._reset();
-      }
-
-      /* Initialize default corners if not already set */
-      if (!this._corners) {
-        if (map.options.zoomAnimation && L.Browser.any3d) {
-          map.on('zoomanim', this._animateZoom, this);
-        }
-      }
-
-      /** if there is a featureGroup, only its editable option matters */
-      const eventParents = this._eventParents;
-      if (eventParents) {
-        this.eP = eventParents[Object.keys(eventParents)[0]];
-        if (this.eP.editable) { this.editing.enable(); }
-      } else {
-        if (this.editable) { this.editing.enable(); }
-        this.eP = null;
-      }
-    });
+    L.DomEvent.on(this.getElement(), 'load', this._initAfterLoading, this);
 
     L.DomEvent.on(this.getElement(), 'click', this.select, this);
     L.DomEvent.on(map, {
@@ -91,6 +63,7 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
   },
 
   onRemove(map) {
+    L.DomEvent.off(this.getElement(), 'load', this._initAfterLoading, this);
     L.DomEvent.off(this.getElement(), 'click', this.select, this);
     L.DomEvent.off(map, {
       singleclickon: this._singleClickListeners,
@@ -106,6 +79,36 @@ L.DistortableImageOverlay = L.ImageOverlay.extend({
 
     L.DomEvent.on(this.getElement(), 'mouseout', this.closeTooltip, this);
     L.DomEvent.off(this.getElement(), 'mousemove', this.deactivateTooltip, this);
+  },
+
+  _initAfterLoading() {
+    this.getPane().appendChild(this.getElement());
+    this._initImageDimensions();
+
+    if (this.options.rotation) {
+      const units = this.options.rotation.deg >= 0 ? 'deg' : 'rad';
+      this.setAngle(this.options.rotation[units], units);
+    } else {
+      this.rotation = {deg: 0, rad: 0};
+      this._reset();
+    }
+
+    /* Initialize default corners if not already set */
+    if (!this._corners) {
+      if (map.options.zoomAnimation && L.Browser.any3d) {
+        map.on('zoomanim', this._animateZoom, this);
+      }
+    }
+
+    /** if there is a featureGroup, only its editable option matters */
+    const eventParents = this._eventParents;
+    if (eventParents) {
+      this.eP = eventParents[Object.keys(eventParents)[0]];
+      if (this.eP.editable) { this.editing.enable(); }
+    } else {
+      if (this.editable) { this.editing.enable(); }
+      this.eP = null;
+    }
   },
 
   _initImageDimensions() {


### PR DESCRIPTION
Fixes #1396

Removing the image before the loading of the image has been finished causes an error in the `load` listener.
![grafik](https://github.com/publiclab/Leaflet.DistortableImage/assets/19800037/b63037a1-db20-45bf-a5e0-965d28cd456a)

**Solution**
Remove the `load` listener when the image is removed